### PR TITLE
Add toolchain options API to WORKSPACE and Bzlmod

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,1 +1,0 @@
-exports_files([".scalafmt.conf"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -95,7 +95,6 @@ use_repo(
     "rules_scala_toolchains",
     "scala_compiler_sources",
 )
-scala_deps.scala()
 
 # Register some of our testing toolchains first when building our repo.
 register_toolchains(
@@ -119,6 +118,7 @@ dev_deps = use_extension(
     "scala_deps",
     dev_dependency = True,
 )
+dev_deps.scala()
 dev_deps.jmh()
 dev_deps.junit()
 dev_deps.scala_proto()

--- a/README.md
+++ b/README.md
@@ -930,19 +930,36 @@ parameter list, which is almost in complete correspondence with parameters from
 the previous macros. The `WORKSPACE` files in this repository also provide many
 examples.
 
-### Replacing toolchain registration macros in `WORKSPACE`
+### Replacing toolchain registration macros
 
 Almost all `rules_scala` toolchains configured using `scala_toolchains()` are
-automatically registered by `scala_register_toolchains()`. There are two
-toolchain macro replacements that require special handling.
+automatically registered by `scala_register_toolchains()`. The same is true for
+toolchains configured using the `scala_deps` module extension under Bzlmod.
+There are two toolchain macro replacements that require special handling.
 
 The first is replacing `scala_proto_register_enable_all_options_toolchain()`
-with the following `scala_toolchains()` parameters:
+with the following:
 
 ```py
+# MODULE.bazel
+
+scala_deps.scala_proto(
+    "default_gen_opts" = [
+        "flat_package",
+        "grpc",
+        "single_line_to_proto_string",
+    ],
+)
+
+# WORKSPACE
 scala_toolchains(
-    scala_proto = True,
-    scala_proto_options = [],
+    scala_proto = {
+        "default_gen_opts": [
+            "flat_package",
+            "grpc",
+            "single_line_to_proto_string",
+        ],
+    },
 )
 ```
 

--- a/docs/phase_scalafmt.md
+++ b/docs/phase_scalafmt.md
@@ -75,7 +75,7 @@ The extension provides a default configuration, but there are 2 ways to use
 a custom configuration:
 
 - Put `.scalafmt.conf` at the root of your workspace
-- Pass `.scalafmt.conf` in via `scala_toolchains`:
+- Pass `.scalafmt.conf` into the toolchain configuration:
 
     ```py
     # MODULE.bazel

--- a/docs/phase_scalafmt.md
+++ b/docs/phase_scalafmt.md
@@ -86,8 +86,7 @@ a custom configuration:
     # WORKSPACE
     scala_toolchains(
         # Other toolchains settings...
-        scalafmt = True,
-        scalafmt_default_config = "//path/to/my/custom:scalafmt.conf",
+        scalafmt = {"default_config": "//path/to/my/custom:scalafmt.conf"},
     )
     ```
 

--- a/docs/phase_scalafmt.md
+++ b/docs/phase_scalafmt.md
@@ -71,24 +71,21 @@ bazel run <TARGET>.format-test
 
 to check the format (without modifying source code).
 
-The extension provides a default configuration, but there are 2 ways to use
-a custom configuration:
+The extension provides a default configuration. To use a custom configuration,
+pass its path or target Label to the toolchain configuration:
 
-- Put `.scalafmt.conf` at the root of your workspace
-- Pass `.scalafmt.conf` into the toolchain configuration:
+```py
+# MODULE.bazel
+scala_deps.scalafmt(
+    default_config = "path/to/my/custom/scalafmt.conf",
+)
 
-    ```py
-    # MODULE.bazel
-    scala_deps.scalafmt(
-        default_config = "//path/to/my/custom:scalafmt.conf",
-    )
-
-    # WORKSPACE
-    scala_toolchains(
-        # Other toolchains settings...
-        scalafmt = {"default_config": "//path/to/my/custom:scalafmt.conf"},
-    )
-    ```
+# WORKSPACE
+scala_toolchains(
+    # Other toolchains settings...
+    scalafmt = {"default_config": "path/to/my/custom/scalafmt.conf"},
+)
+```
 
 When using Scala 3, you must append `runner.dialect = scala3` to
 `.scalafmt.conf`.

--- a/docs/scala_proto_library.md
+++ b/docs/scala_proto_library.md
@@ -1,21 +1,39 @@
 # scala_proto_library
 
-To use this rule, you'll first need to add the following to your `WORKSPACE` file,
-which adds a few dependencies needed for ScalaPB:
+To use this rule, add the following configuration, which adds the dependencies
+needed for ScalaPB:
 
 ```py
-scala_toolchains(
-    # Other toolchains settings...
-    scala_proto = True,
-    scala_proto_options = [
+# MODULE.bazel
+scala_deps.scala_proto(
+    "default_gen_opts" = [
         "grpc",
         "flat_package",
         "scala3_sources",
     ],
 )
+```
+
+```py
+# WORKSPACE
+scala_toolchains(
+    # Other toolchains settings...
+    scala_proto = {
+        "default_gen_opts": [
+            "grpc",
+            "flat_package",
+            "scala3_sources",
+        ],
+    },
+)
 
 scala_register_toolchains()
 ```
+
+See the __scalapbc__ column of the [__ScalaPB: SBT Settings > Additional options
+to the generator__](
+https://scalapb.github.io/docs/sbt-settings#additional-options-to-the-generator
+) table for `default_gen_opts` values.
 
 Then you can import `scala_proto_library` in any `BUILD` file like this:
 

--- a/scala/extensions/deps.bzl
+++ b/scala/extensions/deps.bzl
@@ -96,6 +96,7 @@ _scalafmt_attrs = {
     "default_config": attr.label(
         default = _scalafmt_defaults["default_config"],
         doc = "The default config file for Scalafmt targets",
+        allow_single_file = True,
     ),
 }
 

--- a/scala/extensions/deps.bzl
+++ b/scala/extensions/deps.bzl
@@ -14,8 +14,8 @@ Provides the `scala_deps` module extension with the following tag classes:
 - `twitter_scrooge`
 - `jmh`
 
-For documentation, see the `_tag_classes` dict, and the `_<TAG>_attrs` dict
-corresponding to each `<TAG>` listed above.
+For documentation, see the `_{general,toolchain}_tag_classes` dicts and the
+`_<TAG>_attrs` dict corresponding to each `<TAG>` listed above.
 
 See the `scala/private/macros/bzlmod.bzl` docstring for a description of
 the defaults, attrs, and tag class dictionaries pattern employed here.
@@ -27,6 +27,7 @@ load(
     "root_module_tags",
     "single_tag_values",
 )
+load("//scala/private:toolchain_defaults.bzl", "TOOLCHAIN_DEFAULTS")
 load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//scala:toolchains.bzl", "scala_toolchains")
 
@@ -89,9 +90,7 @@ _compiler_srcjar_attrs = {
     "integrity": attr.string(),
 }
 
-_scalafmt_defaults = {
-    "default_config": "//:.scalafmt.conf",
-}
+_scalafmt_defaults = TOOLCHAIN_DEFAULTS["scalafmt"]
 
 _scalafmt_attrs = {
     "default_config": attr.label(
@@ -100,24 +99,16 @@ _scalafmt_attrs = {
     ),
 }
 
-_scala_proto_defaults = {
-    "options": [],
-}
+_scala_proto_defaults = TOOLCHAIN_DEFAULTS["scala_proto"]
 
 _scala_proto_attrs = {
-    "options": attr.string_list(
-        default = _scala_proto_defaults["options"],
+    "default_gen_opts": attr.string_list(
+        default = _scala_proto_defaults["default_gen_opts"],
         doc = "Protobuf options, like 'scala3_sources' or 'grpc'",
     ),
 }
 
-_twitter_scrooge_defaults = {
-    "libthrift": None,
-    "scrooge_core": None,
-    "scrooge_generator": None,
-    "util_core": None,
-    "util_logging": None,
-}
+_twitter_scrooge_defaults = TOOLCHAIN_DEFAULTS["twitter_scrooge"]
 
 _twitter_scrooge_attrs = {
     k: attr.label(default = v)
@@ -186,39 +177,51 @@ _toolchain_tag_classes = {
     ),
 }
 
+def _toolchain_settings(module_ctx, tags, tc_names, toolchain_defaults):
+    """Configures all builtin toolchains enabled throughout the module graph.
+
+    Configures toolchain options for enabled toolchains that support them based
+    on the root module's settings for each toolchain. In other words, it uses:
+
+    - the root module's tag class settings, if present; and
+    - the default tag class settings otherwise.
+
+    This avoids trying to reconcile different toolchain settings across the
+    module graph. Non root modules that require specific settings should either:
+
+    - publish their required toolchain settings, or
+    - define and register a custom toolchain instead.
+
+    Args:
+        module_ctx: the module context object
+        tags: a tags object, presumably the result of `root_module_tags()`
+        tc_names: names of all supported toolchains
+        toolchain_defaults: a dict of `{toolchain_name: default options dict}`
+
+    Returns:
+        a dict of `{toolchain_name: bool or options dict}` to pass as keyword
+            arguments to `scala_toolchains()`
+    """
+    toolchains = {k: False for k in tc_names}
+
+    for mod in module_ctx.modules:
+        values = {tc: len(getattr(mod.tags, tc)) != 0 for tc in toolchains}
+
+        # Don't overwrite True values with False from another tag.
+        toolchains.update({k: v for k, v in values.items() if v})
+
+    for tc, defaults in toolchain_defaults.items():
+        if toolchains[tc]:
+            values = single_tag_values(module_ctx, getattr(tags, tc), defaults)
+            toolchains[tc] = {k: v for k, v in values.items() if v != None}
+
+    return toolchains
+
 _tag_classes = _general_tag_classes | _toolchain_tag_classes
-
-def _toolchains(mctx):
-    result = {k: False for k in _toolchain_tag_classes}
-
-    for mod in mctx.modules:
-        values = {tc: len(getattr(mod.tags, tc)) != 0 for tc in result}
-
-        if mod.is_root:
-            return values
-
-        # Don't overwrite `True` values with `False` from another tag.
-        result.update({k: v for k, v in values.items() if v})
-
-    return result
-
-def _scala_proto_options(mctx):
-    result = {}
-
-    for mod in mctx.modules:
-        for tag in mod.tags.scala_proto:
-            result.update({opt: True for opt in tag.options})
-
-    return sorted(result.keys())
 
 def _scala_deps_impl(module_ctx):
     tags = root_module_tags(module_ctx, _tag_classes.keys())
-    scalafmt = single_tag_values(module_ctx, tags.scalafmt, _scalafmt_defaults)
-    scrooge_deps = single_tag_values(
-        module_ctx,
-        tags.twitter_scrooge,
-        _twitter_scrooge_defaults,
-    )
+    tc_names = [tc for tc in _toolchain_tag_classes]
 
     scala_toolchains(
         overridden_artifacts = repeated_tag_values(
@@ -229,13 +232,9 @@ def _scala_deps_impl(module_ctx):
             tags.compiler_srcjar,
             _compiler_srcjar_attrs,
         ),
-        scala_proto_options = _scala_proto_options(module_ctx),
-        # `None` breaks the `attr.string_dict` in `scala_toolchains_repo`.
-        twitter_scrooge_deps = {k: v for k, v in scrooge_deps.items() if v},
         **(
             single_tag_values(module_ctx, tags.settings, _settings_defaults) |
-            {"scalafmt_%s" % k: v for k, v in scalafmt.items()} |
-            _toolchains(module_ctx)
+            _toolchain_settings(module_ctx, tags, tc_names, TOOLCHAIN_DEFAULTS)
         )
     )
 

--- a/scala/extensions/deps.bzl
+++ b/scala/extensions/deps.bzl
@@ -244,8 +244,11 @@ scala_deps = module_extension(
     tag_classes = _tag_classes,
     doc = """Selects and configures builtin toolchains.
 
-If the root module explicitly uses the extension, it assumes responsibility for
-selecting all required toolchains by insantiating the corresponding tag classes:
+Modules throughout the dependency graph can enable a builtin toolchain by
+instantiating its corresponding tag class. The root module controls the
+configuration of all toolchains it directly enables. Any other builtin
+toolchain required by other modules will use that toolchain's default
+configuration values.
 
 ```py
 scala_deps = use_extension(
@@ -253,14 +256,14 @@ scala_deps = use_extension(
     "scala_deps",
 )
 scala_deps.scala()
-scala_deps.scala_proto()
+scala_deps.scala_proto(default_gen_opts = ["grpc", "scala3_sources"])
 
 dev_deps = use_extension(
     "@rules_scala//scala/extensions:deps.bzl",
     "scala_deps",
     dev_dependency = True,
 )
-dev_deps.scalafmt()
+dev_deps.scalafmt(default_config = "path/to/scalafmt.conf")
 dev_deps.scalatest()
 
 # And so on...

--- a/scala/private/toolchain_defaults.bzl
+++ b/scala/private/toolchain_defaults.bzl
@@ -1,0 +1,20 @@
+"""Gathers defaults for toolchain macros in one place.
+
+Used by both //scala:toolchains.bzl and //scala/extensions:deps.bzl.
+"""
+
+load(
+    "//scala/scalafmt/toolchain:setup_scalafmt_toolchain.bzl",
+    _scalafmt = "TOOLCHAIN_DEFAULTS",
+)
+load("//scala_proto:toolchains.bzl", _scala_proto = "TOOLCHAIN_DEFAULTS")
+load(
+    "//twitter_scrooge/toolchain:toolchain.bzl",
+    _twitter_scrooge = "TOOLCHAIN_DEFAULTS",
+)
+
+TOOLCHAIN_DEFAULTS = {
+    "scalafmt": _scalafmt,
+    "scala_proto": _scala_proto,
+    "twitter_scrooge": _twitter_scrooge,
+}

--- a/scala/scalafmt/toolchain/setup_scalafmt_toolchain.bzl
+++ b/scala/scalafmt/toolchain/setup_scalafmt_toolchain.bzl
@@ -8,6 +8,13 @@ load("//scala:providers.bzl", "declare_deps_provider")
 load("//scala:scala_cross_version.bzl", "version_suffix")
 load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
+TOOLCHAIN_DEFAULTS = {
+    # Used by `scala_toolchains{,_repo}` to generate
+    # `@rules_scala_toolchains//scalafmt:config`, the default config for
+    # `ext_scalafmt` from `phase_scalafmt_ext.bzl`.
+    "default_config": Label("//:.scalafmt.conf"),
+}
+
 def setup_scalafmt_toolchain(
         name,
         scalafmt_classpath,

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -68,8 +68,9 @@ def _scala_toolchains_repo_impl(repository_ctx):
 
     if repo_attr.scalafmt:
         toolchains["scalafmt"] = _SCALAFMT_TOOLCHAIN_BUILD
-        format_args["scalafmt_default_config"] = (
-            repo_attr.scalafmt_default_config
+        repository_ctx.symlink(
+            repository_ctx.path(repo_attr.scalafmt_default_config),
+            "scalafmt/.scalafmt.conf",
         )
 
     # Generate a root package so that the `register_toolchains` call in
@@ -187,9 +188,9 @@ load(
     "setup_scalafmt_toolchains",
 )
 
-alias(
+filegroup(
     name = "config",
-    actual = "{scalafmt_default_config}",
+    srcs = [":.scalafmt.conf"],
     visibility = ["//visibility:public"],
 )
 

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -68,10 +68,11 @@ def _scala_toolchains_repo_impl(repository_ctx):
 
     if repo_attr.scalafmt:
         toolchains["scalafmt"] = _SCALAFMT_TOOLCHAIN_BUILD
-        repository_ctx.symlink(
-            repository_ctx.path(repo_attr.scalafmt_default_config),
-            "scalafmt/.scalafmt.conf",
-        )
+        config_path = repository_ctx.path(repo_attr.scalafmt_default_config)
+
+        if not config_path.exists:
+            fail("Scalafmt default config file doesn't exist:", config_path)
+        repository_ctx.symlink(config_path, "scalafmt/scalafmt.conf")
 
     # Generate a root package so that the `register_toolchains` call in
     # `MODULE.bazel` always succeeds.
@@ -190,7 +191,7 @@ load(
 
 filegroup(
     name = "config",
-    srcs = [":.scalafmt.conf"],
+    srcs = [":scalafmt.conf"],
     visibility = ["//visibility:public"],
 )
 

--- a/scala_proto/toolchains.bzl
+++ b/scala_proto/toolchains.bzl
@@ -4,11 +4,13 @@ load(
     "scalapb_toolchain",
 )
 
-_default_gen_opts = [
-    "grpc",
-]
+TOOLCHAIN_DEFAULTS = {
+    "default_gen_opts": ["grpc"],
+}
 
-def setup_scala_proto_toolchains(name, default_gen_opts = _default_gen_opts):
+def setup_scala_proto_toolchains(
+        name,
+        default_gen_opts = ["grpc"]):
     """Used by @rules_scala_toolchains//scala_proto/BUILD.
 
     See //scala/private:macros/toolchains_repo.bzl for details, especially the

--- a/scala_proto/toolchains.bzl
+++ b/scala_proto/toolchains.bzl
@@ -16,6 +16,10 @@ def setup_scala_proto_toolchains(
     See //scala/private:macros/toolchains_repo.bzl for details, especially the
     _SCALA_PROTO_TOOLCHAIN_BUILD string template.
 
+    See the `scalapbc` column of the "ScalaPB: SBT Settings > Additional options
+    to the generator" table below for `default_gen_opts` values:
+    - https://scalapb.github.io/docs/sbt-settings#additional-options-to-the-generator
+
     Args:
       name: prefix for all generate toolchains
       default_gen_opts: parameters passed to the default generator

--- a/test_version/MODULE.bazel.template
+++ b/test_version/MODULE.bazel.template
@@ -49,9 +49,7 @@ scala_deps.settings(
     fetch_sources = True,
 )
 scala_deps.scala()
-scala_deps.scala_proto(
-    options = ["grpc"],
-)
+scala_deps.scala_proto()
 scala_deps.scalatest()
 scala_deps.specs2()
 

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -76,8 +76,7 @@ load(
 
 scala_toolchains(
     fetch_sources = True,
-    scala_proto = True,
-    scala_proto_options = ["grpc"],
+    scala_proto = {"default_gen_opts": ["grpc"]},
     scalatest = True,
     specs2 = True,
 )

--- a/test_version/scrooge_repositories.bzl
+++ b/test_version/scrooge_repositories.bzl
@@ -109,6 +109,7 @@ def scrooge_repositories(version = None):
 
     scala_toolchains_repo(
         name = "twitter_scrooge_test_toolchain",
+        scala = False,
         twitter_scrooge = True,
         twitter_scrooge_deps = toolchain_deps,
     )

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -14,14 +14,6 @@ DEP_PROVIDERS = [
     "compiler_classpath",
 ]
 
-TOOLCHAIN_DEPS = [
-    "libthrift",
-    "scrooge_core",
-    "scrooge_generator",
-    "util_core",
-    "util_logging",
-]
-
 def twitter_scrooge_artifact_ids(
         libthrift = None,
         scrooge_core = None,
@@ -77,6 +69,14 @@ export_scrooge_deps = rule(
     },
     toolchains = [_toolchain_type],
 )
+
+TOOLCHAIN_DEFAULTS = {
+    "libthrift": None,
+    "scrooge_core": None,
+    "scrooge_generator": None,
+    "util_core": None,
+    "util_logging": None,
+}
 
 def setup_scrooge_toolchain(
         name,


### PR DESCRIPTION
### Description

Updates `scala_toolchains()` to accept either boolean or dict arguments for specific toolchains, and updates `//scala/extensions:deps.bzl` to generate them from tag classes. Part of #1482.

Notable qualities:

- Adds toolchain options support to the `scala_toolchains()` parameters `scalafmt`, `scala_proto`, and `twitter_scrooge`, and to the `scalafmt` tag class.

- Eliminates the `scalafmt_default_config`, `scala_proto_options`, and `twitter_scrooge_deps` option parameters from `scala_toolchains()`.

- Provides uniform, strict evaluation and validation of toolchain options passed to `scala_toolchains()`.

- Configures enabled toolchains using root module settings or the default toolchain settings only.

- Introduces the shared `TOOLCHAIN_DEFAULTS` dict in `//scala/private:toolchains_defaults.bzl` to aggregate individual `TOOLCHAIN_DEFAULTS` macro parameter dicts.

This change also:

- Replaces the non-dev dependency `scala_deps.scala()` tag instantiation in `MODULE.bazel` with `dev_deps.scala()`.

- Renames the `options` parameter of the `scala_deps.scala_proto` tag class to `default_gen_opts` to match `setup_scala_proto_toolchain()`.

- Introduces `_stringify_args()` to easily pass all toolchain macro args compiled from `scala_toolchains_repo()` attributes through to the generated `BUILD` file.

- Extracts `_DEFAULT_TOOLCHAINS_REPO_NAME` and removes the `scala_toolchains_repo()` macro.

- Includes docstrings for the new private implementation functions, and updates all other docstrings, `README.md`, and other relevant documentation accordingly.

### Motivation

Inspired by @simuons's suggestion to replace toolchain macros with a module extension in:

- https://github.com/bazelbuild/rules_scala/pull/1722#discussion_r2057860067

Though a full replacement is a ways off, this is a step in that direction that surfaced several immediate improvements.

First, extensibility and maintainability:

- The new implementation enables adding options support for other toolchains in the future while maintaining backward compatibility, for both the `WORKSPACE` and Bzlmod APIs. Adding this support will only require a minor release, not a major one.

- The `scala_deps` module extension implementation is easier to read, since all toolchains now share the `_toolchain_settings` mechanism.

Next, improved consistency of the API and implementation:

- Toolchain options parameters should present all the same parameters as the macros to which they correspond, ensured by the `TOOLCHAIN_DEFAULTS` mechanism. This is to make it easier for users and maintainers to see the direct relationship between these separate sets of parameters. (They can also define additional parameters to those required by the macro, like `default_config` from the `scalafmt` options.)

  This principle drove the renaming of the `scala_deps.scala_proto` tag class parameter from `options` to `default_gen_opts`. It also inspired updating `scala_toolchains_repo()` to pass toolchain options through `_stringify_args()` to generate `BUILD` macro arguments.

- The consolidated `TOOLCHAIN_DEFAULTS` dict reduces duplication between the `scala/extensions/deps.bzl` and `scala/toolchains.bzl` files. It ensures consistency between tag class `attr` default values for Bzlmod users and the `scala_toolchains()` default parameter values for `WORKSPACE` users.

  The `TOOLCHAINS_DEFAULTS` dicts corresponding to each toolchain macro do duplicate the information in the macro argument lists. However, the duplicated values in this case are physically adjacent to one another, minimizing the risk of drift.

- Extracting `_DEFAULT_TOOLCHAINS_REPO_NAME` is a step towards enabling customized repositories based on the builtin toolchains, while specifying different options. This extraction revealed the fact that the `scala_toolchains_repo()` macro was no longer necessary, since only `scala_toolchains()` ever called it.

Finally, fixes for the following design bugs:

- Previously, `scala_deps.scala_proto(options = [...])` compiled the list of `default_gen_opts` from all tag instances in the module graph. This might've been convenient, but didn't generalize to other options for other toolchains. In particular, it differed from the previous `toolchains`, `scalafmt`, and `twitter_scrooge` tag class behavior.

  The new semantics are unambiguous, consistent, and apply to all toolchains equally; they do not show a preference for any one toolchain over the others. They also maintain the existing `scalafmt` and `twitter_scrooge` tag class semantics, but now using a generic mechanism, simplifying the implementation.

- Instantating `scala_deps.scala()` was a bug left over from the decision in #1722 _not_ to enable the builtin Scala toolchain by default under Bzlmod.

  The previous `scala_deps.toolchains()` tag class had a default `scala = True` parameter. The user could set `scala = False` to disable the builtin Scala toolchain. After replacing `toolchains()` with individual tag classes, the documented behavior was that the user must enable the builtin Scala toolchain by instantiating `scala_deps.scala()`.

  By instantiating `scala_deps.scala()` in our own `MODULE.bazel` file, we ensured that `rules_scala` would always instantiate the builtin Scala toolchain. While relatively harmless, it violated the intention of allowing the user to avoid instantiating the toolchain altogether.