### PR TITLE
Use the Publish to BCR reusable GitHub workflow

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,16 +1,70 @@
 # Bazel Central Registry publication
 
-The [Publish to BCR GitHub app](https://github.com/bazel-contrib/publish-to-bcr)
-uses these configuration files for publishing Bazel modules to the [Bazel
-Central Registry (BCR)](https://registry.bazel.build/).
+[.github/workflows/publish-to-bcr.yml](../.github/workflows/publish-to-bcr.yml)
+uses these files to configure the [Publish to BCR](
+https://github.com/bazel-contrib/publish-to-bcr) workflow for publishing to the
+[Bazel Central Registry (BCR)](https://registry.bazel.build/).
 
 - [Publish to BCR workflow setup](
-    https://github.com/bazel-contrib/publish-to-bcr/tree/main/README.md#setup)
+    https://github.com/bazel-contrib/publish-to-bcr?tab=readme-ov-file#setup)
 - [.bcr/ templates](
     https://github.com/bazel-contrib/publish-to-bcr/tree/main/templates)
+- [.github/workflows/publish.yaml reusable workflow](
+    https://github.com/bazel-contrib/publish-to-bcr/blob/main/.github/workflows/publish.yaml)
 
-Related documentation:
+Notice that the setup instructions suggest saving the Personal Access Token as
+`PUBLISH_TOKEN`. We save it as `BCR_PUBLISH_TOKEN` instead, as inspired by
+aspect-build/rules_lint#529, to make this value more self documenting.
+
+## Provenance attestations
+
+This workflow also produces attestations required by the [Supply chain Levels
+for Software Artifacts (SLSA)](https://slsa.dev/) framework for secure supply
+chain provenance.
+
+Examples:
+
+<!-- Replace these with rules_scala examples once they're available. -->
+- [aspect-build/rules_lint v1.3.4 release and publish run with attestations](
+    https://github.com/aspect-build/rules_lint/actions/runs/14410869652/attempts/1)
+- [aspect-build/rules_lint v1.3.4 attestations](
+    https://github.com/aspect-build/rules_lint/attestations/6280291)
+- [aspect-build/rules_lint attestations](
+    https://github.com/aspect-build/rules_lint/attestations)
+
+## Related documentation
 
 - [bazelbuild/bazel-central-registry](
     https://github.com/bazelbuild/bazel-central-registry)
+- [SLSA: Provenance](https://slsa.dev/spec/v1.0/provenance)
+- [in-toto](https://in-toto.io/)
 - [GitHub Actions](https://docs.github.com/actions)
+  - [Security for GitHub Actions](
+      https://docs.github.com/en/actions/security-for-github-actions)
+    - [Using secrets in a workflow](
+          https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow)
+    - [Using artifact attestations](
+          https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
+  - [Writing Workflows](
+      https://docs.github.com/en/actions/writing-workflows)
+    - [Accessing contextual information about workflow runs: 'secrets' context](
+          https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#secrets-context)
+    - [Workflow syntax for GitHub Action: 'on.workflow_call.secrets'](
+          https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets)
+  - [Sharing automations](https://docs.github.com/en/actions/sharing-automations)
+    - [Passing inputs and secrets to a reusable workflow](
+          https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow)
+- [actions/attest-build-provenance](
+    https://github.com/actions/attest-build-provenance)
+- [in-toto/attestation](https://github.com/in-toto/attestation)
+- [slsa-framework/slsa-verifier](
+    https://github.com/slsa-framework/slsa-verifier)
+
+## Inspiration
+
+Originally based on the examples from aspect-build/rules_lint#498 and
+aspect-build/rules_lint#501. See also:
+
+- bazelbuild/bazel-central-registry#4060
+- bazelbuild/bazel-central-registry#4146
+- slsa-framework/slsa-verifier#840

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   publish-to-bcr:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.3
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.1.0
     with:
       tag_name: ${{ inputs.tag_name }}
       # bazelbuild/bazel-central-registry fork used to open a pull request.

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -28,7 +28,7 @@ jobs:
     with:
       tag_name: ${{ inputs.tag_name }}
       # bazelbuild/bazel-central-registry fork used to open a pull request.
-      registry_fork: simuons/bazel-central-registry
+      registry_fork: bazel-contrib/bazel-central-registry
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -1,0 +1,38 @@
+# Publishes to the Bazel Central Registry.
+#
+# Based on .github/workflows/publish.yaml from aspect-build/rules_lint v1.3.5.
+# See .bcr/README.md.
+name: Publish to the Bazel Central Registry
+
+on:
+  # Run from release.yml.
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      bcr_publish_token:
+        required: true
+
+  # In case of problems, enable manual dispatch from the GitHub UI.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+jobs:
+  publish-to-bcr:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.0.3
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # bazelbuild/bazel-central-registry fork used to open a pull request.
+      registry_fork: simuons/bazel-central-registry
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork and open a pull request.
+      publish_token: ${{ secrets.bcr_publish_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,21 +7,38 @@ on:
     tags:
       - 'v*.*.*'
 
+  # In case of problems, enable manual dispatch from the GitHub UI.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+
+# Uses the `release_ruleset` workflow to generate provenance attestation files
+# referenced by the `publish-to-bcr` workflow.
+#
+# Based on .github/workflows/release.yml from aspect-build/rules_lint v1.3.5.
+# See .bcr/README.md.
+
+permissions:
+  attestations: write # Needed to attest provenance
+  contents: write # Needed to create release
+  id-token: write # Needed to attest provenance
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.1.0
+    with:
+      bazel_test_command: "bazel test //src/... //test/... //third_party/..."
+      prerelease: false
+      release_files: rules_scala-*.tar.gz
+      release_prep_command: .github/workflows/workspace_snippet.sh
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
 
-      - name: Prepare workspace snippet
-        run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          # Use GH feature to populate the changelog automatically
-          generate_release_notes: true
-          body_path: release_notes.txt
-          fail_on_unmatched_files: true
-          files: rules_scala-*.tar.gz
+  publish-to-bcr:
+    needs: release
+    uses: ./.github/workflows/publish-to-bcr.yml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+    secrets:
+      bcr_publish_token: ${{ secrets.bcr_publish_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.1.0
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       bazel_test_command: "bazel test //src/... //test/... //third_party/..."
       prerelease: false


### PR DESCRIPTION
### Description

Updates `.github/workflows/release.yml` and adds `publish-to-bcr.yml` for publishing to the Bazel Central Registry. Part of #1482 (originally broken out from #1722).

`release.yml` now uses the `release_ruleset` workflow from `bazel-contrib/.github`, which does everything `release.yml` did previously and adds SLSA provenance attestations. `release.yml` then invokes the new `publish-to-bcr.yml` workflow after publishing a successful release to GitHub.

Requires that the `BCR_PUBLISH_TOKEN` GitHub secret and the `registry_fork` specified in `.github/workflows/publish-to-bcr.yml` are in place.

See `.bcr/README.md` for all the details and references.

### Motivation

This will enable automated publishing to https://registry.bazel.build/.