### PR TITLE
Fix Scalafmt `default_config` docs for `WORKSPACE`

### DIFF
--- a/docs/phase_scalafmt.md
+++ b/docs/phase_scalafmt.md
@@ -72,18 +72,21 @@ bazel run <TARGET>.format-test
 to check the format (without modifying source code).
 
 The extension provides a default configuration. To use a custom configuration,
-pass its path or target Label to the toolchain configuration:
+pass its path or target `Label` string to the toolchain configuration. The file
+must exist within a package; the following examples presume a `BUILD` file
+exists in the repository root:
 
 ```py
 # MODULE.bazel
 scala_deps.scalafmt(
-    default_config = "path/to/my/custom/scalafmt.conf",
+    default_config = "path/to/my/custom/.scalafmt.conf",
 )
 
 # WORKSPACE
 scala_toolchains(
     # Other toolchains settings...
-    scalafmt = {"default_config": "path/to/my/custom/scalafmt.conf"},
+    # This _must_ be a target Label under WORKSPACE.
+    scalafmt = {"default_config": "//:path/to/my/custom/.scalafmt.conf"},
 )
 ```
 


### PR DESCRIPTION
### Description

Makes it clear that `WORKSPACE` users must use a target `Label` string with the `default_config` option for the `scalafmt` argument of `scala_toolchains`. Notes that the specified config file must exist within a package, including but not limited to having a `BUILD` file in the repository root.

### Motivation

@gergelyfabian noticed this while building gergelyfabian/bazel-scala-example after #1730 landed.

This isn't fixable in code. With this call:

```py
scala_toolchains(
    # Other toolchains...
    scalafmt = {"default_config": ".scalafmt.conf"},
)
```

- `scala_toolchains` looks for the file under `external/.scalafmt.conf`.

- Updating `scala_toolchains` to wrap `default_config` in a `Label` makes it relative to `@rules_scala//scala`. This because `scala_toolchains` resides in `@rules_scala//scala:toolchains.bzl`.

- `native.package_relative_label` is only available when called from a `BUILD` file.

Hence `default_config` values under `WORKSPACE` must be valid target labels.

The problem doesn't exist under Bzlmod; plain file paths will work fine, so long as a `BUILD` file exists at the repository root.