### PR TITLE
Fixing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
       bazel_test_command: "bazel test //src/... //test/... //third_party/..."
       prerelease: false
       release_files: rules_scala-*.tar.gz
-      release_prep_command: .github/workflows/workspace_snippet.sh
       tag_name: ${{ inputs.tag_name || github.ref_name }}
 
   publish-to-bcr:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -2,9 +2,8 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Set by GH actions, see
-# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-TAG="${GITHUB_REF_NAME}"
+# Single tag arg is passed by https://github.com/bazel-contrib/.github/blob/master/.github/workflows/release_ruleset.yaml
+TAG="$1"
 VERSION="${TAG:1}"
 PREFIX="rules_scala-${VERSION}"
 ARCHIVE="rules_scala-$TAG.tar.gz"


### PR DESCRIPTION
### Motivation

Release attempt failed https://github.com/bazel-contrib/rules_scala/actions/runs/14926599712

release_prep_command was removed in https://github.com/bazel-contrib/.github/pull/32

workspace_snippet.sh was renabed to release_prep.sh this is a hardcoded path that release workflow expects
