### PR TITLE
chore: update GH org in BCR metadata

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/bazelbuild/rules_scala",
+  "homepage": "https://github.com/bazel-contrib/rules_scala",
   "maintainers": [
     {
       "name": "Simonas Pinevičius",
@@ -13,7 +13,7 @@
     }
   ],
   "repository": [
-    "github:bazelbuild/rules_scala"
+    "github:bazel-contrib/rules_scala"
   ],
   "versions": [],
   "yanked_versions": {}

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -29,6 +29,8 @@ jobs:
       tag_name: ${{ inputs.tag_name }}
       # bazelbuild/bazel-central-registry fork used to open a pull request.
       registry_fork: bazel-contrib/bazel-central-registry
+      # No need to create a draft since PRs are opened by a machine account
+      draft: false
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
Fixes the validation errors from first attempt at publishing v7.0.0

https://buildkite.com/bazel/bcr-presubmit/builds/13834