### PR TITLE
Fix last_green build after disable_autoloads flip

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -302,3 +302,4 @@ use_repo(
 )
 
 bazel_dep(name = "rules_python", version = "1.4.0", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.1", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,3 +144,20 @@ load("//scala/private/extensions:dev_deps.bzl", "dev_deps_repositories")
 dev_deps_repositories()
 
 register_toolchains("//test/toolchains:java21_toolchain_definition")
+
+http_archive(
+    name = "rules_shell",
+    sha256 = "bc61ef94facc78e20a645726f64756e5e285a045037c7a61f65af2941f4c25e1",
+    strip_prefix = "rules_shell-0.4.1",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz",
+)
+
+load(
+    "@rules_shell//shell:repositories.bzl",
+    "rules_shell_dependencies",
+    "rules_shell_toolchains",
+)
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()

--- a/deps/test/BUILD.bazel.test
+++ b/deps/test/BUILD.bazel.test
@@ -8,6 +8,7 @@ load(
     "scalafmt_scala_test",
     "scrooge_transitive_outputs_test",
 )
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_scala//jmh:jmh.bzl", "scala_benchmark_jmh")
 load("@rules_scala//scala/scalafmt:phase_scalafmt_ext.bzl", "ext_scalafmt")
@@ -89,11 +90,37 @@ default_outputs_test(
 )
 
 # From: `test/jmh/BUILD`
+java_library(
+    name = "java_type",
+    srcs = ["JavaType.java"],
+    visibility = ["//visibility:public"],
+)
+
+scala_library(
+    name = "scala_type",
+    srcs = ["ScalaType.scala"],
+    visibility = ["//visibility:public"],
+)
+
+scala_library(
+    name = "add_numbers",
+    srcs = ["AddNumbers.scala"],
+    visibility = ["//visibility:public"],
+    exports = [
+        ":java_type",
+        ":scala_type",
+    ],
+    deps = [
+        ":java_type",
+        ":scala_type",
+    ],
+)
+
 scala_benchmark_jmh(
     name = "test_benchmark",
     srcs = ["TestBenchmark.scala"],
     data = ["data.txt"],
-    deps = ["@rules_scala//test/jmh:add_numbers"],
+    deps = [":add_numbers"],
 )
 
 # From: `test/src/main/scala/scalarules/test/twitter_scrooge/BUILD`

--- a/deps/test/defs.bzl
+++ b/deps/test/defs.bzl
@@ -1,5 +1,6 @@
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("@rules_scala//scala:advanced_usage/scala.bzl", "make_scala_test")
 load("@rules_scala//scala/scalafmt:phase_scalafmt_ext.bzl", "ext_scalafmt")
 

--- a/examples/semanticdb/BUILD
+++ b/examples/semanticdb/BUILD
@@ -1,5 +1,5 @@
-load("@rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
 load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "semanticdb_toolchain_impl",

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//scala/private:rules/scala_binary.bzl", "scala_binary")
 load("//scala/private:rules/scala_library.bzl", "scala_library")
 

--- a/jmh/toolchain/toolchain.bzl
+++ b/jmh/toolchain/toolchain.bzl
@@ -1,10 +1,10 @@
-load("//scala/private/toolchain_deps:toolchain_deps.bzl", "expose_toolchain_deps")
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 load("//scala:providers.bzl", "declare_deps_provider", _DepsInfo = "DepsInfo")
 load(
     "//scala:scala_cross_version.bzl",
     _versioned_repositories = "repositories",
 )
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("//scala/private/toolchain_deps:toolchain_deps.bzl", "expose_toolchain_deps")
 
 DEP_PROVIDERS = [
     "jmh_classpath",

--- a/manual_test/scala_test_jacocorunner/BUILD
+++ b/manual_test/scala_test_jacocorunner/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_test")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "passing_toolchain_impl",

--- a/manual_test/scala_test_jvm_flags/BUILD
+++ b/manual_test/scala_test_jvm_flags/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_test")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/manual_test/scalac_jvm_opts/BUILD
+++ b/manual_test/scalac_jvm_opts/BUILD
@@ -1,6 +1,6 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_library")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala_proto:scala_proto.bzl", "scala_proto_library")
 
 scala_toolchain(

--- a/protoc/private/protoc_toolchains.bzl
+++ b/protoc/private/protoc_toolchains.bzl
@@ -3,14 +3,14 @@
 Provides precompiled protocol compiler toolchains.
 """
 
+load("@com_google_protobuf//:protobuf_version.bzl", "PROTOC_VERSION")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load(":private/protoc_integrity.bzl", "PROTOC_BUILDS", "PROTOC_DOWNLOAD_URL")
 load(
     ":private/toolchain_impl.bzl",
     "PROTOC_TOOLCHAIN_ENABLED",
     "PROTOC_TOOLCHAIN_TYPE",
 )
-load("@com_google_protobuf//:protobuf_version.bzl", "PROTOC_VERSION")
-load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 
 def _default_platform():
     host_platform = sorted(HOST_CONSTRAINTS)

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,7 +1,7 @@
-load("//scala:scala_cross_version.bzl", "version_suffix")
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
 load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 toolchain_type(
     name = "toolchain_type",

--- a/scala/extensions/config.bzl
+++ b/scala/extensions/config.bzl
@@ -5,14 +5,14 @@ See the `_settings_attrs` dict for documentation.
 """
 
 load(
-    "//scala/private:macros/bzlmod.bzl",
-    "root_module_tags",
-    "single_tag_values",
-)
-load(
     "//:scala_config.bzl",
     "DEFAULT_SCALA_VERSION",
     _scala_config = "scala_config",
+)
+load(
+    "//scala/private:macros/bzlmod.bzl",
+    "root_module_tags",
+    "single_tag_values",
 )
 
 _settings_defaults = {

--- a/scala/extensions/deps.bzl
+++ b/scala/extensions/deps.bzl
@@ -21,6 +21,8 @@ See the `scala/private/macros/bzlmod.bzl` docstring for a description of
 the defaults, attrs, and tag class dictionaries pattern employed here.
 """
 
+load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
+load("//scala:toolchains.bzl", "scala_toolchains")
 load(
     "//scala/private:macros/bzlmod.bzl",
     "repeated_tag_values",
@@ -28,8 +30,6 @@ load(
     "single_tag_values",
 )
 load("//scala/private:toolchain_defaults.bzl", "TOOLCHAIN_DEFAULTS")
-load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
-load("//scala:toolchains.bzl", "scala_toolchains")
 
 _settings_defaults = {
     "maven_servers": default_maven_server_urls(),

--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -1,7 +1,8 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("//scala:plusone.bzl", "PlusOneDeps")
 load("//scala:providers.bzl", "ScalaInfo")
-load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def write_manifest_file(actions, output_file, main_class):
     # TODO(bazel-team): I don't think this classpath is what you want

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -1,12 +1,14 @@
 """Shared attributes for rules"""
 
-load(
-    "//scala/private:coverage_replacements_provider.bzl",
-    _coverage_replacements_provider = "coverage_replacements_provider",
-)
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load(
     "//scala:plusone.bzl",
     _collect_plus_one_deps_aspect = "collect_plus_one_deps_aspect",
+)
+load(
+    "//scala/private:coverage_replacements_provider.bzl",
+    _coverage_replacements_provider = "coverage_replacements_provider",
 )
 
 common_attrs_for_plugin_bootstrapping = {

--- a/scala/private/coverage_replacements_provider.bzl
+++ b/scala/private/coverage_replacements_provider.bzl
@@ -18,6 +18,8 @@
 # duplicate providers.
 #
 
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
 _CoverageReplacements = provider(
     fields = {
         "replacements": "hash of files to swap out",

--- a/scala/private/extensions/dev_deps.bzl
+++ b/scala/private/extensions/dev_deps.bzl
@@ -1,14 +1,14 @@
 """Repositories for testing rules_scala itself"""
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
+load("//scala:scala_maven_import_external.bzl", "java_import_external")
 load(
     "//scala/private:macros/bzlmod.bzl",
     "root_module_tags",
     "single_tag_values",
 )
-load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
-load("//scala:scala_maven_import_external.bzl", "java_import_external")
 load("//third_party/repositories:repositories.bzl", "repositories")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 _BUILD_TOOLS_RELEASE = "5.1.0"
 

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -1,11 +1,11 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 load(
     "//scala:scala_cross_version.bzl",
     "extract_major_version",
     "extract_minor_version",
     "version_suffix",
 )
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 def _dt_patched_compiler_impl(rctx):
     # Need to give the file a .zip extension so rctx.extract knows what type of archive it is

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -1,7 +1,7 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 load("//scala:providers.bzl", "declare_deps_provider")
 load("//scala:scala_cross_version.bzl", "repositories", "version_suffix")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 def setup_scala_toolchain(
         name,

--- a/scala/private/macros/test/BUILD.bzlmod_test
+++ b/scala/private/macros/test/BUILD.bzlmod_test
@@ -1,11 +1,12 @@
 """Used by test/shell/test_bzlmod_helpers.sh to test bzlmod.bzl."""
 
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(
     "@test_tag_values//:results.bzl",
     "FIRST",
+    "REPEATED",
     "SECOND",
     "THIRD",
-    "REPEATED",
 )
 
 sh_binary(

--- a/scala/private/macros/test/MODULE.bzlmod_test
+++ b/scala/private/macros/test/MODULE.bzlmod_test
@@ -16,3 +16,5 @@ dev_test_ext = use_extension(
     "test_ext",
     dev_dependency = True,
 )
+
+bazel_dep(name = "rules_shell", version = "0.4.1")

--- a/scala/private/phases/api.bzl
+++ b/scala/private/phases/api.bzl
@@ -2,11 +2,11 @@
 The phase API for rules implementation
 """
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "//scala:advanced_usage/providers.bzl",
     _ScalaRulePhase = "ScalaRulePhase",
 )
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 # A method to modify the built-in phase list
 # - Insert new phases to the first/last position

--- a/scala/private/phases/phase_collect_jars.bzl
+++ b/scala/private/phases/phase_collect_jars.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
 #
 # PHASE: collect jars
 #

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -1,3 +1,6 @@
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
 #
 # PHASE: compile
 #

--- a/scala/private/phases/phase_jvm_flags.bzl
+++ b/scala/private/phases/phase_jvm_flags.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
 #
 # PHASE: jvm flags
 #

--- a/scala/private/phases/phase_scalac_provider.bzl
+++ b/scala/private/phases/phase_scalac_provider.bzl
@@ -1,10 +1,11 @@
+load("//scala:providers.bzl", _ScalacProvider = "ScalacProvider")
+
 #
 # PHASE: scalac provider
 #
 # DOCUMENT THIS
 #
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
-load("//scala:providers.bzl", _ScalacProvider = "ScalacProvider")
 
 def phase_scalac_provider(ctx, p):
     toolchain_type_label = "//scala:toolchain_type"

--- a/scala/private/phases/phase_semanticdb.bzl
+++ b/scala/private/phases/phase_semanticdb.bzl
@@ -1,6 +1,7 @@
-load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
-load("//scala:semanticdb_provider.bzl", "SemanticdbInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:semanticdb_provider.bzl", "SemanticdbInfo")
+load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 
 def phase_semanticdb(ctx, p):
     #semanticdb_bundle_in_jar feature: enables bundling the semanticdb files within the output jar.

--- a/scala/private/phases/phases.bzl
+++ b/scala/private/phases/phases.bzl
@@ -7,6 +7,7 @@ load(
     _extras_phases = "extras_phases",
     _run_phases = "run_phases",
 )
+load("//scala/private:phases/phase_collect_exports_jars.bzl", _phase_collect_exports_jars = "phase_collect_exports_jars")
 load(
     "//scala/private:phases/phase_collect_jars.bzl",
     _phase_collect_jars_common = "phase_collect_jars_common",
@@ -15,7 +16,6 @@ load(
     _phase_collect_jars_repl = "phase_collect_jars_repl",
     _phase_collect_jars_scalatest = "phase_collect_jars_scalatest",
 )
-load("//scala/private:phases/phase_collect_exports_jars.bzl", _phase_collect_exports_jars = "phase_collect_exports_jars")
 load("//scala/private:phases/phase_collect_srcjars.bzl", _phase_collect_srcjars = "phase_collect_srcjars")
 load(
     "//scala/private:phases/phase_compile.bzl",

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -14,6 +14,7 @@
 """Rules for supporting the Scala language."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//toolchains:toolchain_utils.bzl", "find_java_toolchain")
 load(":common.bzl", "rlocationpath_from_rootpath", _collect_plugin_paths = "collect_plugin_paths")
 load(":resources.bzl", _resource_paths = "paths")

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -1,6 +1,9 @@
 """Builds Scala binaries"""
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:common_attributes.bzl",
     "common_attrs",
@@ -9,7 +12,6 @@ load(
     "resolve_deps",
 )
 load("//scala/private:common_outputs.bzl", "common_outputs")
-load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:phases/phases.bzl",
     "extras_phases",

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -1,7 +1,8 @@
 """Scaladoc support"""
 
-load("//scala/private:common.bzl", "collect_plugin_paths")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//scala:providers.bzl", "ScalaInfo")
+load("//scala/private:common.bzl", "collect_plugin_paths")
 
 ScaladocAspectInfo = provider(fields = [
     "src_files",  #depset[File]

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -1,6 +1,9 @@
 """Rules for writing tests with JUnit"""
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:common_attributes.bzl",
     "common_attrs",
@@ -8,7 +11,6 @@ load(
     "launcher_template",
 )
 load("//scala/private:common_outputs.bzl", "common_outputs")
-load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:phases/phases.bzl",
     "extras_phases",

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -1,4 +1,6 @@
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:common.bzl",
     "sanitize_string_for_usage",
@@ -15,7 +17,6 @@ load(
     "//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
-load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:phases/phases.bzl",
     "extras_phases",

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -1,6 +1,8 @@
 """Rule for launching a Scala REPL with dependencies"""
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:common_attributes.bzl",
     "common_attrs",
@@ -9,7 +11,6 @@ load(
     "resolve_deps",
 )
 load("//scala/private:common_outputs.bzl", "common_outputs")
-load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:phases/phases.bzl",
     "extras_phases",

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -1,15 +1,16 @@
 """Rules for writing tests with ScalaTest"""
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+load("//scala/private:common.bzl", "sanitize_string_for_usage")
 load(
     "//scala/private:common_attributes.bzl",
     "common_attrs",
     "implicit_deps",
     "launcher_template",
 )
-load("//scala/private:common.bzl", "sanitize_string_for_usage")
 load("//scala/private:common_outputs.bzl", "common_outputs")
-load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "//scala/private:phases/phases.bzl",
     "extras_phases",

--- a/scala/private/toolchain_deps/toolchain_deps.bzl
+++ b/scala/private/toolchain_deps/toolchain_deps.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//scala:providers.bzl", "DepsInfo")
 
 def _required_deps_id_message(target, toolchain_type_label, deps_id):

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -1,8 +1,4 @@
 load(
-    "//specs2:specs2_junit.bzl",
-    _specs2_junit_dependencies = "specs2_junit_dependencies",
-)
-load(
     "//scala/private:macros/setup_scala_toolchain.bzl",
     _setup_scala_toolchain = "setup_scala_toolchain",
 )
@@ -35,6 +31,10 @@ load(
     "//scala/private:rules/scala_test.bzl",
     _scala_test = "scala_test",
     _scala_test_suite = "scala_test_suite",
+)
+load(
+    "//specs2:specs2_junit.bzl",
+    _specs2_junit_dependencies = "specs2_junit_dependencies",
 )
 
 def scala_specs2_junit_test(name, **kwargs):

--- a/scala/scala_cross_version_select.bzl
+++ b/scala/scala_cross_version_select.bzl
@@ -1,5 +1,5 @@
-load(":scala_cross_version.bzl", "version_suffix")
 load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+load(":scala_cross_version.bzl", "version_suffix")
 
 def select_for_scala_version(default = [], **kwargs):
     """

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -1,6 +1,8 @@
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("//scala/private:rule_impls.bzl", "specified_java_compile_toolchain")
 load("//scala/settings:stamp_settings.bzl", "StampScalaImport")
-load("//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 
 def _stamp_jar(ctx, jar):
     stamped_jar_filename = "%s.stamp/%s" % (ctx.label.name, jar.basename)

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -1,10 +1,10 @@
-load("//scala:providers.bzl", _DepsInfo = "DepsInfo")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "@rules_scala_config//:config.bzl",
     "ENABLE_COMPILER_DEPENDENCY_TRACKING",
     "SCALA_MAJOR_VERSION",
 )
+load("//scala:providers.bzl", _DepsInfo = "DepsInfo")
 
 def _compute_strict_deps_mode(input_strict_deps_mode, dependency_mode):
     if dependency_mode == "direct":

--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -1,9 +1,9 @@
-load("//scala/scalafmt/toolchain:toolchain.bzl", "export_scalafmt_deps")
-load("//scala/scalafmt:phase_scalafmt_ext.bzl", "scalafmt_singleton")
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 load("//scala:scala.bzl", "scala_binary")
 load("//scala:scala_cross_version.bzl", "version_suffix")
 load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("//scala/scalafmt:phase_scalafmt_ext.bzl", "scalafmt_singleton")
+load("//scala/scalafmt/toolchain:toolchain.bzl", "export_scalafmt_deps")
 
 filegroup(
     name = "runner",

--- a/scala/scalafmt/toolchain/setup_scalafmt_toolchain.bzl
+++ b/scala/scalafmt/toolchain/setup_scalafmt_toolchain.bzl
@@ -1,12 +1,12 @@
+load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+load("//scala:providers.bzl", "declare_deps_provider")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_artifact_ids")
 load(
     "//scala/scalafmt/toolchain:toolchain.bzl",
     "SCALAFMT_TOOLCHAIN_TYPE",
     "scalafmt_toolchain",
 )
-load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_artifact_ids")
-load("//scala:providers.bzl", "declare_deps_provider")
-load("//scala:scala_cross_version.bzl", "version_suffix")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 TOOLCHAIN_DEFAULTS = {
     # Used by `scala_toolchains{,_repo}` to generate

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -1,7 +1,10 @@
 """Macros to instantiate and register @rules_scala_toolchains"""
 
+load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 load("//jmh/toolchain:toolchain.bzl", "jmh_artifact_ids")
 load("//junit:junit.bzl", "junit_artifact_ids")
+load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
+load("//scala:toolchains_repo.bzl", "scala_toolchains_repo")
 load(
     "//scala/private:macros/scala_repositories.bzl",
     "scala_version_artifact_ids",
@@ -9,8 +12,6 @@ load(
 )
 load("//scala/private:toolchain_defaults.bzl", "TOOLCHAIN_DEFAULTS")
 load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_artifact_ids")
-load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
-load("//scala:toolchains_repo.bzl", "scala_toolchains_repo")
 load("//scala_proto/default:repositories.bzl", "scala_proto_artifact_ids")
 load("//scalatest:scalatest.bzl", "scalatest_artifact_ids")
 load("//specs2:specs2.bzl", "specs2_artifact_ids")
@@ -20,7 +21,6 @@ load(
     "//twitter_scrooge/toolchain:toolchain.bzl",
     "twitter_scrooge_artifact_ids",
 )
-load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 _DEFAULT_TOOLCHAINS_REPO_NAME = "rules_scala_toolchains"
 

--- a/scala_proto/default/default_deps.bzl
+++ b/scala_proto/default/default_deps.bzl
@@ -7,9 +7,9 @@
 # dependency lists. This needs to be the unrolled transitive path to be used
 # without such a facility.
 
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 load("//scala:scala_cross_version.bzl", "repositories")
 load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 _DEFAULT_DEP_PROVIDER_FORMAT = (
     "@rules_scala_toolchains//scala_proto:scalapb_%s_deps_provider"

--- a/scala_proto/private/scala_proto.bzl
+++ b/scala_proto/private/scala_proto.bzl
@@ -1,15 +1,17 @@
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
-load(
-    "//scala_proto/private:scala_proto_aspect_provider.bzl",
-    "ScalaProtoAspectInfo",
-)
 load(
     "//scala/private:phases/api.bzl",
     "extras_phases",
     "run_phases",
 )
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//scala_proto/private:scala_proto_aspect.bzl", "make_scala_proto_aspect")
+load(
+    "//scala_proto/private:scala_proto_aspect_provider.bzl",
+    "ScalaProtoAspectInfo",
+)
 
 def phase_merge_aspect_java_info(ctx, p):
     java_info = java_common.merge([dep[ScalaProtoAspectInfo].java_info for dep in ctx.attr.deps])

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -1,4 +1,6 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("//scala/private:common.bzl", "write_manifest_file")
 load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_protobuf_scrooge")

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load(
     "//protoc:private/toolchain_impl.bzl",
     "PROTOC_ATTR",
@@ -9,7 +10,6 @@ load(
     "//scala_proto/default:default_deps.bzl",
     _scala_proto_deps_providers = "scala_proto_deps_providers",
 )
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 
 def _generators_jars(ctx):
     generator_deps = ctx.attr.extra_generator_dependencies + [

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,7 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(
     "//scala:scala.bzl",
     "scala_binary",
@@ -13,9 +17,6 @@ load(
 )
 load("//scala:scala_cross_version.bzl", "repositories")
 load(":check_statsfile.bzl", "check_statsfile")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("@rules_python//python:defs.bzl", "py_binary")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 package(default_testonly = 1)
 

--- a/test/aspect/BUILD
+++ b/test/aspect/BUILD
@@ -1,5 +1,4 @@
-load(":aspect.bzl", "aspect_testscript")
-load(":javainfo_from_aspect_test.bzl", "javainfo_from_aspect_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(
     "//scala:scala.bzl",
     "scala_junit_test",
@@ -8,6 +7,8 @@ load(
     "scala_test",
 )
 load("//scala:scala_import.bzl", "scala_import")
+load(":aspect.bzl", "aspect_testscript")
+load(":javainfo_from_aspect_test.bzl", "javainfo_from_aspect_test")
 
 aspect_testscript(
     name = "aspect_testscript",

--- a/test/aspect/javainfo_from_aspect_test.bzl
+++ b/test/aspect/javainfo_from_aspect_test.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 
 _VisitedRulesInfo = provider()
 

--- a/test/diagnostics_reporter/BUILD
+++ b/test/diagnostics_reporter/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 load("@rules_java//java:defs.bzl", "java_binary")
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 java_binary(
     name = "diagnostics_reporter_test",

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,6 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_library")
-load("//scala:scala.bzl", "scala_library", "scala_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//jmh:jmh.bzl", "scala_benchmark_jmh")
+load("//scala:scala.bzl", "scala_library", "scala_test")
 
 java_library(
     name = "java_type",

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -1,12 +1,12 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
-    "//scala_proto:scala_proto.bzl",
-    "scala_proto_library",
-)
-load(
     "//scala:scala.bzl",
     "scala_binary",
     "scala_test",
+)
+load(
+    "//scala_proto:scala_proto.bzl",
+    "scala_proto_library",
 )
 load(
     "//scala_proto:scala_proto_toolchain.bzl",

--- a/test/proto/custom_generator/BUILD.bazel
+++ b/test/proto/custom_generator/BUILD.bazel
@@ -1,6 +1,5 @@
 load("//scala:providers.bzl", "declare_deps_provider")
 load("//scala:scala.bzl", "scala_library", "scala_test")
-load("//scala_proto/default:default_deps.bzl", "DEFAULT_SCALAPB_WORKER_DEPS")
 load("//scala_proto:scala_proto.bzl", "scala_proto_library")
 load(
     "//scala_proto:scala_proto_toolchain.bzl",
@@ -8,6 +7,7 @@ load(
     "scala_proto_deps_toolchain",
     "scala_proto_toolchain",
 )
+load("//scala_proto/default:default_deps.bzl", "DEFAULT_SCALAPB_WORKER_DEPS")
 
 # This package contains manual tests for custom generators:
 #

--- a/test/proto3/BUILD
+++ b/test/proto3/BUILD
@@ -1,8 +1,8 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//scala_proto:scala_proto.bzl",
     "scala_proto_library",
 )
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 genrule(
     name = "generated",

--- a/test/semanticdb/BUILD
+++ b/test/semanticdb/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_library")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//test/semanticdb:rules.bzl", "semanticdb_vars_script")
 
 scala_toolchain(

--- a/test/src/main/scala/scalarules/test/scala_import/nl/BUILD.bazel
+++ b/test/src/main/scala/scalarules/test/scala_import/nl/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//scala:scala.bzl", "scala_specs2_junit_test")
 load("//scala:scala_import.bzl", "scala_import")
-load("@rules_java//java:defs.bzl", "java_library")
 
 java_library(
     name = "scala_import_never_link",

--- a/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//scala:scala_import.bzl", "scala_import")
 load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
 

--- a/test/src/main/scala/scalarules/test/srcjars/pack_sources_test.bzl
+++ b/test/src/main/scala/scalarules/test/srcjars/pack_sources_test.bzl
@@ -1,5 +1,6 @@
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 
 # Tests and documents the functionality of phase_compile.bzl's _pack_source_jar
 

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/BUILD
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/BUILD
@@ -1,7 +1,8 @@
 load("@rules_java//java:defs.bzl", "java_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//scala:scala.bzl", "scala_binary", "scala_library")
-load("//twitter_scrooge:twitter_scrooge.bzl", "scrooge_java_library", "scrooge_scala_library")
 load("//test/src/main/scala/scalarules/test/twitter_scrooge:twitter_scrooge_test.bzl", "twitter_scrooge_test_suite")
+load("//twitter_scrooge:twitter_scrooge.bzl", "scrooge_java_library", "scrooge_scala_library")
 
 scrooge_scala_library(
     name = "scrooge1",

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/twitter_scrooge_test.bzl
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/twitter_scrooge_test.bzl
@@ -1,5 +1,6 @@
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 
 def _scrooge_transitive_outputs(ctx):
     env = unittest.begin(ctx)

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load(
     "@rules_java//toolchains:default_java_toolchain.bzl",
     "BASE_JDK9_JVM_OPTS",
@@ -6,6 +5,7 @@ load(
     "DEFAULT_TOOLCHAIN_CONFIGURATION",
     "default_java_toolchain",
 )
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 default_java_toolchain(
     name = "java21_toolchain",

--- a/test_dependency_versions.sh
+++ b/test_dependency_versions.sh
@@ -146,7 +146,7 @@ do_build_and_test() {
   cp \
     "${dir}"/deps/test/*.{scala,bzl} \
     "${dir}"/examples/testing/multi_frameworks_toolchain/example/*.scala \
-    "${dir}"/test/jmh/{TestBenchmark.scala,data.txt} \
+    "${dir}"/test/jmh/{AddNumbers.scala,JavaType.java,ScalaType.scala,TestBenchmark.scala,data.txt} \
     "${dir}"/test/proto/standalone.proto \
     "${dir}"/test/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/thrift3/Thrift3.thrift \
     .

--- a/test_expect_failure/diagnostics_reporter/BUILD
+++ b/test_expect_failure/diagnostics_reporter/BUILD
@@ -1,6 +1,6 @@
 load("//scala:scala.bzl", "scala_library")
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "diagnostics_reporter_toolchain_impl",

--- a/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
+++ b/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
 #This rule is an example for a jvm rule that doesn't support Jars2Labels
 def _custom_jvm_impl(ctx):
     # TODO(#8867): Migrate away from the placeholder jar hack when #8867 is fixed.

--- a/test_expect_failure/missing_direct_deps/scala_proto_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/scala_proto_deps/BUILD
@@ -1,5 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_java//java:defs.bzl", "java_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//scala:scala.bzl", "scala_library")
 load("//scala_proto:scala_proto.bzl", "scala_proto_library")
 load("//scala_proto:scala_proto_toolchain.bzl", "scalapb_toolchain")

--- a/test_expect_failure/missing_direct_deps/scala_proto_deps/customized_scala_proto.bzl
+++ b/test_expect_failure/missing_direct_deps/scala_proto_deps/customized_scala_proto.bzl
@@ -1,5 +1,5 @@
-load("//scala_proto:scala_proto.bzl", "make_scala_proto_aspect", "make_scala_proto_library")
 load("//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("//scala_proto:scala_proto.bzl", "make_scala_proto_aspect", "make_scala_proto_library")
 
 def _phase_custom_stamping_convention(ctx, p):
     rule_label = str(p.target.label)

--- a/test_expect_failure/scala_test_jacocorunner/BUILD
+++ b/test_expect_failure/scala_test_jacocorunner/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_test")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/test_expect_failure/scala_test_jvm_flags/BUILD
+++ b/test_expect_failure/scala_test_jvm_flags/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_test")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/test_expect_failure/scalac_jvm_opts/BUILD
+++ b/test_expect_failure/scalac_jvm_opts/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_library")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/test_expect_failure/scalacopts_from_toolchain/BUILD
+++ b/test_expect_failure/scalacopts_from_toolchain/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_library")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/test_expect_failure/scaladoc/BUILD
+++ b/test_expect_failure/scaladoc/BUILD
@@ -1,6 +1,6 @@
-load("scaladoc.bzl", "scala_doc_intransitive")
 load("//scala:scala.bzl", "scala_doc", "scala_library")
 load("//scala:scala_import.bzl", "scala_import")
+load("scaladoc.bzl", "scala_doc_intransitive")
 
 package(default_testonly = 1)
 

--- a/test_expect_failure/unused_dependency_checker/BUILD
+++ b/test_expect_failure/unused_dependency_checker/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_library")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/test_version/MODULE.bazel.template
+++ b/test_version/MODULE.bazel.template
@@ -16,6 +16,7 @@ local_path_override(
 
 bazel_dep(name = "rules_java", version = "8.11.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(
     name = "protobuf",
     version = "30.2",

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -26,6 +26,23 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 http_archive(
+    name = "rules_shell",
+    sha256 = "bc61ef94facc78e20a645726f64756e5e285a045037c7a61f65af2941f4c25e1",
+    strip_prefix = "rules_shell-0.4.1",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz",
+)
+
+load(
+    "@rules_shell//shell:repositories.bzl",
+    "rules_shell_dependencies",
+    "rules_shell_toolchains",
+)
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
+http_archive(
     name = "rules_python",
     sha256 = "a837679f1382f26968c1ee6f839c7daf9079aa53128069a1f2815decaa637304",
     strip_prefix = "rules_python-1.4.0",

--- a/test_version/scrooge_repositories.bzl
+++ b/test_version/scrooge_repositories.bzl
@@ -10,11 +10,11 @@ load(
     "@rules_scala//scala:toolchains_repo.bzl",
     "scala_toolchains_repo",
 )
+load("@rules_scala//third_party/repositories:repositories.bzl", "repositories")
 load(
     "@rules_scala//twitter_scrooge/toolchain:toolchain.bzl",
     "twitter_scrooge_artifact_ids",
 )
-load("@rules_scala//third_party/repositories:repositories.bzl", "repositories")
 load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def _import_external(id, artifact, sha256, deps = [], runtime_deps = []):

--- a/test_version/test_reporter/BUILD
+++ b/test_version/test_reporter/BUILD
@@ -1,5 +1,5 @@
-load("@rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
 load("@rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "diagnostics_reporter_toolchain_impl",

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -9,6 +9,7 @@ load(
     "scala_specs2_junit_test",
     "scala_test",
 )
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 package(default_testonly = 1)
 

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/BUILD
@@ -1,5 +1,6 @@
 load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 load("@rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 scrooge_scala_library(
     name = "scrooge1",

--- a/test_version/version_specific_tests_dir/twitter_scrooge/BUILD
+++ b/test_version/version_specific_tests_dir/twitter_scrooge/BUILD
@@ -1,3 +1,5 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 dependencies_to_test = [
     "scrooge_core",
     "scrooge_generator",

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,5 +1,5 @@
-load("//scala:scala_cross_version.bzl", "version_suffix")
 load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("//scala:scala_cross_version.bzl", "version_suffix")
 
 # Aliases for backward compatibility:
 [

--- a/testing/testing.bzl
+++ b/testing/testing.bzl
@@ -1,3 +1,4 @@
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 load("//junit:junit.bzl", "junit_artifact_ids")
 load("//scala:providers.bzl", "declare_deps_provider")
 load("//scala:scala_cross_version.bzl", "version_suffix")
@@ -5,7 +6,6 @@ load("//scalatest:scalatest.bzl", "scalatest_artifact_ids")
 load("//specs2:specs2.bzl", "specs2_artifact_ids")
 load("//specs2:specs2_junit.bzl", "specs2_junit_artifact_ids")
 load("//testing/toolchain:toolchain.bzl", "scala_testing_toolchain")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def _repoize(ids):
     return ["@" + id for id in ids]

--- a/testing/toolchain/BUILD
+++ b/testing/toolchain/BUILD
@@ -1,5 +1,5 @@
-load(":toolchain_deps.bzl", "testing_toolchain_deps")
 load("//testing:testing.bzl", "DEP_PROVIDERS")
+load(":toolchain_deps.bzl", "testing_toolchain_deps")
 
 toolchain_type(
     name = "testing_toolchain_type",

--- a/third_party/dependency_analyzer/src/test/analyzer_test.bzl
+++ b/third_party/dependency_analyzer/src/test/analyzer_test.bzl
@@ -1,11 +1,11 @@
-load("//scala:scala.bzl", "scala_test")
-load("//scala:scala_cross_version.bzl", "version_suffix")
-load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 load(
     "@rules_scala_config//:config.bzl",
     "SCALA_MAJOR_VERSION",
     "SCALA_VERSION",
 )
+load("//scala:scala.bzl", "scala_test")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 def tests():
     suffix = version_suffix(SCALA_VERSION)

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -1,3 +1,4 @@
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 load(
     "//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
@@ -58,7 +59,6 @@ load(
     _artifacts_3_7 = "artifacts",
     _scala_version_3_7 = "scala_version",
 )
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 artifacts_by_major_scala_version = {
     "2.11": _artifacts_2_11,

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -1,11 +1,11 @@
+load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("//scala:providers.bzl", "DepsInfo", "declare_deps_provider")
+load("//scala:scala_cross_version.bzl", "version_suffix")
 load(
     "//scala/private/toolchain_deps:toolchain_deps.bzl",
     "expose_toolchain_deps",
 )
-load("//scala:providers.bzl", "DepsInfo", "declare_deps_provider")
-load("//scala:scala_cross_version.bzl", "version_suffix")
 load("//scala_proto/default:repositories.bzl", "GUAVA_ARTIFACT_IDS")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 DEP_PROVIDERS = [
     "compile_classpath",

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -1,4 +1,6 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load(
     "//scala/private:common.bzl",
     "write_manifest_file",


### PR DESCRIPTION
### Description

Explicitly loads all symbols affected by `--incompatible_disable_autoloads_in_main_repo` to fix `last_green` Bazel builds. Adds `rules_shell` as a dev dependency and updates files to fix `test_bzlmod_macros.sh` and `test_dependency_versions.sh`.

As a result of using Buildifier to add the missing `load` statements, Buildifier reordered the `load` statements as well.

Fixes the following breakage when using the `last_green` build from bazelbuild/bazel@f08d561385a5bcbd2f7e5341820fe35cc813bdd3 (and other breakages blocked by this one):

```sh
$ bazel run //tools:lint_check

ERROR: scala/private/rules/scala_test.bzl:130:21:
  name 'JavaInfo' is not defined

ERROR: .../external/+dev_deps+com_github_bazelbuild_buildtools/buildifier/BUILD.bazel:3:10:
  While resolving toolchains for target
  @@+dev_deps+com_github_bazelbuild_buildtools//buildifier:buildifier
  (b5bbebe): invalid registered toolchain
  '//test/proto:scalapb_toolchain':
  error loading package 'test/proto':
  at /Users/mbland/src/bazel-contrib/rules_scala/scala/scala.bzl:35:5:
  compilation of module 'scala/private/rules/scala_test.bzl' failed

ERROR: Analysis of target '//tools:lint_check' failed; build aborted:
  Analysis failed
```

Fixed using Buildifier 8.2.0 by first running the following to get the list of appropriate warnings:

```txt
buildifier --lint=warn -r . 2>&1 | grep -- native- |
  awk '{print $2}' | sort | uniq
```

then running:

```txt
buildifier --lint=fix \
  --warnings=native-java-common,native-java-info,native-sh-test,native-sh-binary \
  -r .
```

I also ran it separately on the changed files in `deps/test` and `scala/private/macros/test`, since Buildifier didn't automatically find them.

### Motivation

bazelbuild/bazel@d87eaf5d6fd41b54da59708f859fd80da8fcd303 from 2025-05-08 at 8:03am EDT flipped
`--incompatible_disable_autoloads_in_main_repo` to `true` to prepare for Bazel 9. I did confirm that setting
`--noincompatible_disable_autoloads_in_main_repo` resolved the breakage before using Buildifier to add the necessary `load` statements.

Pull request #1735 was the last to pass the `last_green` CI build using bazelbuild/bazel@94e0b442cc44859f62a8081d8ffba7051ab6199e from 2025-05-08 at 7:39am EDT. This was two commits before the commit that flipped `--incompatible_disable_autoloads_in_main_repo`:

- https://buildkite.com/bazel/rules-scala-scala/builds/5596#0196afc2-4af3-4202-8232-d5f5fe113349

Pull request #1736 failed the `last_green` CI build using bazelbuild/bazel@cac54c46e5fd14b202066e7da8d05ddc098357c5 from 2025-05-09 at 6:14am EDT. That job ran on 2025-05-09 at 6:47am EDT. The `last_green` configuration in `.bazelci/presubmit.yml` emits a warning if the build fails. This warning was present on the build page, but we've overlooked it until now:

- https://buildkite.com/bazel/rules-scala-scala/builds/5598#0196b4a8-e593-431a-ab4c-8d8471d9b08b

Part of this change copies more files from `test/jmh` into the `test_dependency_versions.sh` test directory. It also replicates targets from `//test/jmh` in `deps/test/BUILD.bazel.test` to replace the previous dependency on `@rules_scala//test/jmh:add_numbers`.

This is because `//test/jmh` now has a `load` dependency on `@rules_shell`, which is a `dev_dependency` of `@rules_scala`. Since `@rules_shell` isn't visible to `@rules_scala` when it isn't the root module, this broke the build within `test_dependency_versions.sh`.