### PR TITLE
Check for 'deps' attr in scala_doc rule

### DIFF
--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -33,9 +33,10 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
 
     macro_classpath = []
 
-    for dependency in ctx.rule.attr.deps:
-        if ScalaInfo in dependency and dependency[ScalaInfo].contains_macros:
-            macro_classpath.append(dependency[JavaInfo].transitive_runtime_jars)
+    if hasattr(ctx.rule.attr, "deps"):
+        for dependency in ctx.rule.attr.deps:
+            if ScalaInfo in dependency and dependency[ScalaInfo].contains_macros:
+                macro_classpath.append(dependency[JavaInfo].transitive_runtime_jars)
 
     # Sometimes we only want to generate scaladocs for a single target and not all of its
     # dependencies

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -1,7 +1,7 @@
 """Scaladoc support"""
 
-load("//scala/private:common.bzl", "collect_plugin_paths")
 load("//scala:providers.bzl", "ScalaInfo")
+load("//scala/private:common.bzl", "collect_plugin_paths")
 
 ScaladocAspectInfo = provider(fields = [
     "src_files",  #depset[File]
@@ -33,10 +33,9 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
 
     macro_classpath = []
 
-    if hasattr(ctx.rule.attr, "deps"):
-        for dependency in ctx.rule.attr.deps:
-            if ScalaInfo in dependency and dependency[ScalaInfo].contains_macros:
-                macro_classpath.append(dependency[JavaInfo].transitive_runtime_jars)
+    for dependency in getattr(ctx.rule.attr, "deps", []):
+        if ScalaInfo in dependency and dependency[ScalaInfo].contains_macros:
+            macro_classpath.append(dependency[JavaInfo].transitive_runtime_jars)
 
     # Sometimes we only want to generate scaladocs for a single target and not all of its
     # dependencies

--- a/test/shell/test_macros.sh
+++ b/test/shell/test_macros.sh
@@ -5,7 +5,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 incorrect_macro_user_does_not_build() {
-  (! bazel build //test/macros:incorrect-macro-user) |&
+  (! bazel build //test/macros:incorrect-macro-user) 2>&1 |
     grep --fixed-strings 'Build failure during macro expansion. You may have declared a target containing a macro as a `scala_library` target instead of a `scala_macro_library` target'
 }
 


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

Add a guard for `deps` existing in `ctx.rules.attr` when generating `scala_docs`.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

As a side note: Would the maintainers be interested in a `scala_export` rule in `rules_scala`? I [implemented](https://github.com/confluentinc/rules_jvm_external/blob/master/private/rules/scala_export.bzl) this in our rules_jvm_external fork but it won't be [upstreamed](https://github.com/bazel-contrib/rules_jvm_external/pull/1257#issuecomment-2428908599).

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

It's possible to for `ctx.rules.attr` to not have `deps`. Specifically, I ran into a failure generating `scala_docs` when a `maven_project_jar` is in the deps of the `scala_library`.
