### PR TITLE
Upgrade Scala versions 3.7.0 -> 3.7.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ SCALA_3_VERSIONS = [
     "3.3.6",
     "3.5.2",
     "3.6.4",
-    "3.7.0",
+    "3.7.1",
 ]
 
 SCALA_VERSIONS = SCALA_2_VERSIONS + SCALA_3_VERSIONS

--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -118,7 +118,7 @@ $runner test_compiler_patch 3.3.6
 $runner test_compiler_patch 3.4.3
 $runner test_compiler_patch 3.5.2
 $runner test_compiler_patch 3.6.4
-$runner test_compiler_patch 3.7.0
+$runner test_compiler_patch 3.7.1
 
 $runner test_compiler_srcjar_error 2.12.11
 $runner test_compiler_srcjar_error 2.12.12
@@ -151,4 +151,4 @@ $runner test_compiler_srcjar_nonhermetic 3.3.6
 $runner test_compiler_srcjar 3.4.3
 $runner test_compiler_srcjar_nonhermetic 3.5.2
 $runner test_compiler_srcjar_nonhermetic 3.6.4
-$runner test_compiler_srcjar_nonhermetic 3.7.0
+$runner test_compiler_srcjar_nonhermetic 3.7.1

--- a/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel
+++ b/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel
@@ -170,8 +170,8 @@ scala_deps.compiler_srcjar(
     version = "3.6.4",
 )
 scala_deps.compiler_srcjar(
-    url = "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.0/scala3-compiler_3-3.7.0-sources.jar",
-    version = "3.7.0",
+    url = "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.1/scala3-compiler_3-3.7.1-sources.jar",
+    version = "3.7.1",
 )
 
 scala_protoc = use_extension(

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -147,8 +147,8 @@ srcjars_by_version = {
     "3.6.4": {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.6.4/scala3-compiler_3-3.6.4-sources.jar",
     },
-    "3.7.0": {
-        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.0/scala3-compiler_3-3.7.0-sources.jar",
+    "3.7.1": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.1/scala3-compiler_3-3.7.1-sources.jar",
     },
 }
 

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -62,7 +62,7 @@ scala_protoc_toolchains(name = "rules_scala_protoc_toolchains")
 
 load("@rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "3.7.0")
+scala_config(scala_version = "3.7.1")
 
 load(
     "@rules_scala//scala:toolchains.bzl",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,7 +51,7 @@ options:
                         Scala version for which to update repository
                         information; if not provided, updates all supported
                         versions: 2.11.12, 2.12.20, 2.13.16, 3.1.3, 3.2.2,
-                        3.3.6, 3.4.3, 3.5.2, 3.6.4, 3.7.0
+                        3.3.6, 3.4.3, 3.5.2, 3.6.4, 3.7.1
   --output_dir OUTPUT_DIR
                         Directory in which to generate or update repository
                         files (default: .../third_party/repositories)

--- a/scripts/create_repository.py
+++ b/scripts/create_repository.py
@@ -24,7 +24,7 @@ ROOT_SCALA_VERSIONS = [
     "3.4.3",
     "3.5.2",
     "3.6.4",
-    "3.7.0",
+    "3.7.1",
 ]
 PARSER_COMBINATORS_VERSION = '1.1.2'
 SBT_COMPILER_INTERFACE_VERSION = '1.10.8'

--- a/test/shell/test_examples.sh
+++ b/test/shell/test_examples.sh
@@ -54,7 +54,7 @@ function scala3_6_example() {
 }
 
 function scala3_7_example() {
-   test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.7.0 //..."
+   test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.7.1 //..."
 }
 
 function semanticdb_example() {

--- a/test_thirdparty_version.sh
+++ b/test_thirdparty_version.sh
@@ -15,7 +15,7 @@ runner=$(get_test_runner "${1:-local}")
 
 
 # Latest version of each major version
-$runner test_scala_version "3.7.0" # Latest Next version
+$runner test_scala_version "3.7.1" # Latest Next version
 $runner test_scala_version "3.3.6" # Latest LTS version
 $runner test_scala_version "3.1.3" # First supported major for Scala 3, max supported JDK=18
 $runner test_scala_version "2.13.16"

--- a/third_party/repositories/scala_3_7.bzl
+++ b/third_party/repositories/scala_3_7.bzl
@@ -3,7 +3,7 @@
 Mostly generated and updated by scripts/create_repository.py.
 """
 
-scala_version = "3.7.0"
+scala_version = "3.7.1"
 
 artifacts = {
     "com_github_jnr_jffi_native": {
@@ -186,12 +186,12 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_scala_asm": {
-        "artifact": "org.scala-lang.modules:scala-asm:9.7.1-scala-1",
-        "sha256": "3b764f500ee290ad44ff03db92c0de2b3ed920a1df531eab35a793f79b786379",
+        "artifact": "org.scala-lang.modules:scala-asm:9.8.0-scala-1",
+        "sha256": "86af037580bdf9ce9c05f8b2afd734daf1a8564c38cd10ca5d08bf81508ad2e4",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala3-compiler_3:3.7.0",
-        "sha256": "c98aa98625b1907d604a7095cf0021fe46bf9fc63d6a462c5042098cac7f4372",
+        "artifact": "org.scala-lang:scala3-compiler_3:3.7.1",
+        "sha256": "3ad6529be3723d342a56b0283f41044fa539b51308d0ceb4b2f1ca1161fc4fd0",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@io_bazel_rules_scala_scala_interfaces",
@@ -214,12 +214,12 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_scala_interfaces": {
-        "artifact": "org.scala-lang:scala3-interfaces:3.7.0",
-        "sha256": "afa940f0fffa93a2b3ce09a80bfb6f1e1aea6fa3a2160368bfced6f39fc55604",
+        "artifact": "org.scala-lang:scala3-interfaces:3.7.1",
+        "sha256": "273f477c705cbd31fee764ffb3434af7b50af8613d5246bfb76febb317cd95d4",
     },
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala3-library_3:3.7.0",
-        "sha256": "6edd0cb7160d9b7bf5a0b13ae8a978001764778f15c888379d576877a27475af",
+        "artifact": "org.scala-lang:scala3-library_3:3.7.1",
+        "sha256": "09b95af8163e6a81c8ce9bf0aad9547a982effa15067cc8d71fa763317117233",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -250,8 +250,8 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_scala_tasty_core": {
-        "artifact": "org.scala-lang:tasty-core_3:3.7.0",
-        "sha256": "7e677d86449b1524757273457316cfb7a4b6994efa2fc53e323e3085045b7cd1",
+        "artifact": "org.scala-lang:tasty-core_3:3.7.1",
+        "sha256": "ae6b3e3d22fa2da81ef200cf59c66daa935e9991eb2402a66a0e294236066117",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],


### PR DESCRIPTION
### Description
Upgrades Scala 3.7 to latest patch version


### Motivation
https://github.com/scala/scala3/issues/23301