### PR TITLE
Make java library earlier on classpath

### DIFF
--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -250,7 +250,7 @@ def _compile_or_empty(
             full_jars.append(java_jar.jar)
 
         if java_jar:
-            merged_provider = java_common.merge([scala_compilation_provider, java_jar.java_compilation_provider])
+            merged_provider = java_common.merge([java_jar.java_compilation_provider, scala_compilation_provider])
         else:
             merged_provider = scala_compilation_provider
 


### PR DESCRIPTION
### Description
I have a `scala_library` with some java files where I would like to override the class for a particular dependency (i.e. something from `@maven//`).

> This is a common idiom for monkey patching some functionality.

In order for this to work, the Java file needs to be first on the _classpath_.
@rules_scala seems to be placing the generated `java_library` at the end of the CLASSPATH.

This change makes it so that it's first. 
