### PR TITLE
Fix builds for Bazel >= 9.0.0-pre.20250714.1

### DIFF
--- a/scala/private/extensions/dev_deps.bzl
+++ b/scala/private/extensions/dev_deps.bzl
@@ -64,7 +64,7 @@ def dev_deps_repositories(
     java_import_external(
         name = "org_apache_commons_commons_lang_3_5_without_file",
         generated_linkable_rule_name = "linkable_org_apache_commons_commons_lang_3_5_without_file",
-        jar_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
+        artifact_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
         jar_urls = ["https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"],
         licenses = ["notice"],  # Apache 2.0
         neverlink = True,

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -141,9 +141,9 @@ def _jvm_import_external_impl(repository_ctx):
     repository_ctx.file("jar/BUILD", "\n".join([
         _HEADER,
         "",
-        "package(default_visibility = %r)" %
-        (repository_ctx.attr.visibility or
-         repository_ctx.attr.default_visibility),
+        "package(default_visibility = %r)" % (
+            repository_ctx.attr.default_visibility,
+        ),
         "",
         "alias(",
         "    name = \"jar\",",


### PR DESCRIPTION
### Description

Resolves the following `last_green` CI build error resulting from the following changes appearing in Bazel 9.0.0-pre.20250714.1:

- https://buildkite.com/bazel/rules-scala-scala/builds/5701#019839bb-2124-4600-a91c-ece2eedc46fa/122-218
- https://github.com/bazelbuild/bazel/pull/26493/files#diff-47a01c886ef9dc97641591dd4dd08157ef1414496979456380830acc9f694e65R67-R72
- https://github.com/bazelbuild/bazel/pull/26493/files#diff-47a01c886ef9dc97641591dd4dd08157ef1414496979456380830acc9f694e65R101

```txt
$ USE_BAZEL_VERSION=9.0.0-pre.20250714.1 bazel test //src/... //test/...

ERROR: scala/scala_maven_import_external.bzl:145:29:
  An error occurred during the fetch of repository
  '+scala_deps+scala_proto_rules_scalapb_protoc_gen_2_12_20':

  Traceback (most recent call last):
    File "scala/scala_maven_import_external.bzl", line 145, column 29,
    in _jvm_import_external_impl
      (repository_ctx.attr.visibility or

Error: unknown attribute visibility

ERROR: no such package
    '@@+scala_deps+scala_proto_rules_scalapb_protoc_gen_2_12_20//':
    unknown attribute visibility

ERROR: test/proto/custom_generator/BUILD.bazel:44:22:
  //test/proto/custom_generator:scalapb_worker_deps_provider depends on
  @@+scala_deps+scala_proto_rules_scalapb_protoc_gen_2_12_20//:scala_proto_rules_scalapb_protoc_gen_2_12_20
  in repository
  @@+scala_deps+scala_proto_rules_scalapb_protoc_gen_2_12_20
  which failed to fetch.

  no such package
  '@@+scala_deps+scala_proto_rules_scalapb_protoc_gen_2_12_20//':
  unknown attribute visibility

ERROR: Analysis of target
  '//test/proto/custom_generator:scala_proto_deps_toolchain_def' failed;
  build aborted: Analysis failed
```

Another problem remains, but it appears to be on Bazel's end per bazelbuild/bazel#26579 (stemming from bazelbuild/bazel#26477):

```txt
$ USE_BAZEL_VERSION=9.0.0-pre.20250714.1 bazel test //src/... //test/...

ERROR: error loading package '@@bazel_tools//src/main/protobuf':
  Unable to find package for
  @@[unknown repo 'grpc-java' requested from @@bazel_tools]//:java_grpc_library.bzl:

  The repository '@@[unknown repo 'grpc-java' requested from @@bazel_tools]'
  could not be resolved:
  No repository visible as '@grpc-java' from repository '@@bazel_tools'.

ERROR: src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD:3:12:
  error loading package '@@bazel_tools//src/main/protobuf':
  Unable to find package for
  @@[unknown repo 'grpc-java' requested from @@bazel_tools]//:java_grpc_library.bzl:

  The repository '@@[unknown repo 'grpc-java' requested from @@bazel_tools]'
  could not be resolved:
  No repository visible as '@grpc-java' from repository '@@bazel_tools'.
  and referenced by
  '//src/java/io/bazel/rulesscala/coverage/instrumenter:instrumenter'

ERROR: Analysis of target '//test/aspect:scala_junit_test' failed;
  build aborted: Analysis failed
```

Neither of these errors occurred when building with Bazel 9.0.0-pre.20250710.1.

The `scala/private/extensions/dev_deps.bzl` update eliminates the warning:

```txt
DEBUG: scala/scala_maven_import_external.bzl:80:14:
  'jar_sha256' is deprecated. Please use 'artifact_sha256'
```

### Motivation

It seems prudent to address this `last_green` failure separately from bumping dependency versions before releasing v7.1.0. We'll have to wait for an upstream fix for bazelbuild/bazel#26579, however. Once it appears, though, the `last_green` build should succeed again, with this change already in place.

Also, ostensibly, `repository_ctx.attr.visibility` was never a valid value for `package(default_visibility = ...)`. Removing it seems more correct than `getattr(repository_ctx, "visibility", [])`.