### PR TITLE
Fix BCR presubmit, update rules_python to 1.5.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -303,5 +303,5 @@ use_repo(
     "org_golang_x_tools",
 )
 
-bazel_dep(name = "rules_python", version = "1.5.1", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.5.2", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.5.1", dev_dependency = True)

--- a/examples/crossbuild/protobuf.patch
+++ b/examples/crossbuild/protobuf.patch
@@ -1,1 +1,91 @@
-../../protoc/0001-protobuf-19679-rm-protoc-dep.patch
+diff --git a/protobuf.bzl b/protobuf.bzl
+index 283c85850..ad91faba6 100644
+--- a/protobuf.bzl
++++ b/protobuf.bzl
+@@ -1,7 +1,9 @@
+ load("@bazel_skylib//lib:versions.bzl", "versions")
+ load("@rules_cc//cc:defs.bzl", "objc_library")
+ load("@rules_python//python:defs.bzl", "py_library")
++load("//bazel/common:proto_common.bzl", "proto_common")
+ load("//bazel/common:proto_info.bzl", "ProtoInfo")
++load("//bazel/private:toolchain_helpers.bzl", "toolchains")
+ 
+ def _GetPath(ctx, path):
+     if ctx.label.workspace_root:
+@@ -71,6 +73,26 @@ def _CsharpOuts(srcs):
+         for src in srcs
+     ]
+ 
++_PROTOC_ATTRS = toolchains.if_legacy_toolchain({
++    "_proto_compiler": attr.label(
++        cfg = "exec",
++        executable = True,
++        allow_files = True,
++        default = configuration_field("proto", "proto_compiler"),
++    ),
++})
++_PROTOC_FRAGMENTS = ["proto"]
++_PROTOC_TOOLCHAINS = toolchains.use_toolchain(toolchains.PROTO_TOOLCHAIN)
++
++def _protoc_files_to_run(ctx):
++    if proto_common.INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION:
++        toolchain = ctx.toolchains[toolchains.PROTO_TOOLCHAIN]
++        if not toolchain:
++            fail("Protocol compiler toolchain could not be resolved.")
++        return toolchain.proto.proto_compiler
++    else:
++        return ctx.attr._proto_compiler[DefaultInfo].files_to_run
++
+ ProtoGenInfo = provider(
+     fields = ["srcs", "import_flags", "deps"],
+ )
+@@ -310,7 +332,7 @@ def _internal_gen_well_known_protos_java_impl(ctx):
+             args.add_all([src.path[offset:] for src in dep.direct_sources])
+ 
+     ctx.actions.run(
+-        executable = ctx.executable._protoc,
++        executable = _protoc_files_to_run(ctx),
+         inputs = descriptors,
+         outputs = [srcjar],
+         arguments = [args],
+@@ -334,12 +356,9 @@ internal_gen_well_known_protos_java = rule(
+         "javalite": attr.bool(
+             default = False,
+         ),
+-        "_protoc": attr.label(
+-            executable = True,
+-            cfg = "exec",
+-            default = "//:protoc",
+-        ),
+-    },
++    } | _PROTOC_ATTRS,
++    fragments = _PROTOC_FRAGMENTS,
++    toolchains = _PROTOC_TOOLCHAINS,
+ )
+ 
+ def _internal_gen_kt_protos(ctx):
+@@ -373,7 +392,7 @@ def _internal_gen_kt_protos(ctx):
+             args.add_all([src.path[offset:] for src in dep.direct_sources])
+ 
+     ctx.actions.run(
+-        executable = ctx.executable._protoc,
++        executable = _protoc_files_to_run(ctx),
+         inputs = descriptors,
+         outputs = [srcjar],
+         arguments = [args],
+@@ -397,12 +416,9 @@ internal_gen_kt_protos = rule(
+         "lite": attr.bool(
+             default = False,
+         ),
+-        "_protoc": attr.label(
+-            executable = True,
+-            cfg = "exec",
+-            default = "//:protoc",
+-        ),
+-    },
++    } | _PROTOC_ATTRS,
++    fragments = _PROTOC_FRAGMENTS,
++    toolchains = _PROTOC_TOOLCHAINS,
+ )
+ 
+ def internal_objc_proto_library(

--- a/scala/latest_deps.bzl
+++ b/scala/latest_deps.bzl
@@ -71,17 +71,12 @@ def rules_scala_dependencies():
         ),
     )
 
-    # Can't upgrade for now because https://github.com/bazel-contrib/rules_python/pull/2760
-    # broke Bazel 7 WORKSPACE builds. It's really only a dev dep anyway.
-    # If it's fixed per https://github.com/bazel-contrib/rules_python/issues/3119
-    # (i.e., once https://github.com/bazel-contrib/rules_python/pull/3134 lands),
-    # then we can upgrade.
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "9f9f3b300a9264e4c77999312ce663be5dee9a56e361a1f6fe7ec60e1beef9a3",
-        strip_prefix = "rules_python-1.4.1",
-        url = "https://github.com/bazelbuild/rules_python/releases/download/1.4.1/rules_python-1.4.1.tar.gz",
+        sha256 = "0e68f851a6fcf317eeab5f6dc79803cb183d30c0c65fb52e2c4b731d13b73349",
+        strip_prefix = "rules_python-1.5.2",
+        url = "https://github.com/bazelbuild/rules_python/releases/download/1.5.2/rules_python-1.5.2.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
### Description

Resolves the Windows symlink breakage from bazelbuild/bazel-central-registry#5490 by replacing `examples/crossbuild/protobuf.patch` with a full copy. Bumps `rules_python` to 1.5.2 for both Bzlmod and legacy WORKSPACE builds.

### Motivation

This is hopefully a temporary measure to unblock the next `rules_scala` release. This will probably require creating a v7.1.1 tag to trigger a new `.bcr/presubmit.yml` workflow.

See bazelbuild/bazel-central-registry#5506 for details about the breakage. If and when bazelbuild/continuous-integration#2350 lands and makes its way to the BCR presubmit build, we could restore the symlink. Better yet, if protocolbuffers/protobuf#19679 ever lands, we could remove this symlink and all the others.

Bumped `rules_python` to 1.5.2 for legacy `WORKSPACE` builds because it contains bazel-contrib/rules_python#3134, which fixes bazel-contrib/rules_python#3119.
