### PR TITLE
fix: string + label concatenation error

### DIFF
--- a/protoc/private/toolchain_impl.bzl
+++ b/protoc/private/toolchain_impl.bzl
@@ -45,5 +45,5 @@ def protoc_executable(ctx):
 
     toolchain = ctx.toolchains[PROTOC_TOOLCHAIN_TYPE]
     if not toolchain:
-        fail("Couldn't resolve protocol compiler for " + PROTOC_TOOLCHAIN_TYPE)
+        fail("Couldn't resolve protocol compiler for " + str(PROTOC_TOOLCHAIN_TYPE))
     return toolchain.proto.proto_compiler.executable


### PR DESCRIPTION
### Description

Removal of string + label concatenation error when someone do not register rules_scala's PROTOC_TOOLCHAIN_TYPE


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation

-
