### PR TITLE
soft_fail CI tasks, upgrade to rules_python-1.6.0

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -146,7 +146,7 @@ tasks:
     - "bash ./test_dependency_versions.sh" # script removes ./ from BASH_SOURCE
   bcr_presubmit:
     # Keep in sync with .bcr/presubmit.yml.
-    name: BCR ${{ bcr_bazel }}
+    name: "BCR {bcr_bazel}"
     working_directory: "examples/crossbuild"
     platform: ${{ bcr_platform }}
     bazel: ${{ bcr_bazel }}

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -146,7 +146,7 @@ tasks:
     - "bash ./test_dependency_versions.sh" # script removes ./ from BASH_SOURCE
   bcr_presubmit:
     # Keep in sync with .bcr/presubmit.yml.
-    name: "BCR presubmit ${{ bcr_bazel }}"
+    name: BCR ${{ bcr_bazel }}
     working_directory: "examples/crossbuild"
     platform: ${{ bcr_platform }}
     bazel: ${{ bcr_bazel }}

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -41,7 +41,9 @@ tasks:
     shell_commands:
     # Install xmllint
     - sudo apt update && sudo apt install --reinstall libxml2-utils -y
-    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Optional build with last_green Bazel version failed, [see here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}) (It is not mandatory but worth checking)\""
+    - "./test_rules_scala.sh"
+    soft_fail:
+      - exit_status: "*"
   test_rules_scala_macos:
     name: "./test_rules_scala"
     platform: macos
@@ -144,7 +146,7 @@ tasks:
     - "bash ./test_dependency_versions.sh" # script removes ./ from BASH_SOURCE
   bcr_presubmit:
     # Keep in sync with .bcr/presubmit.yml.
-    name: "BCR presubmit"
+    name: "BCR presubmit ${{ bcr_bazel }}"
     working_directory: "examples/crossbuild"
     platform: ${{ bcr_platform }}
     bazel: ${{ bcr_bazel }}
@@ -152,3 +154,5 @@ tasks:
       - "//..."
     test_targets:
       - "//..."
+    soft_fail:
+      - exit_status: "*"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -304,5 +304,5 @@ use_repo(
     "org_golang_x_tools",
 )
 
-bazel_dep(name = "rules_python", version = "1.6.0-rc0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.6.0", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.6.0", dev_dependency = True)

--- a/scala/latest_deps.bzl
+++ b/scala/latest_deps.bzl
@@ -56,9 +56,9 @@ def rules_scala_dependencies():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "3664a03376fc2441e2dec357000b3a80119e2ea062ea1be41418daeb91451055",
-        strip_prefix = "rules_python-1.6.0-rc0",
-        url = "https://github.com/bazel-contrib/rules_python/releases/download/1.6.0-rc0/rules_python-1.6.0-rc0.tar.gz",
+        sha256 = "fa7dd2c6b7d63b3585028dd8a90a6cf9db83c33b250959c2ee7b583a6c130e12",
+        strip_prefix = "rules_python-1.6.0",
+        url = "https://github.com/bazel-contrib/rules_python/releases/download/1.6.0/rules_python-1.6.0.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
### Description

Updates the `test_rules_scala_linux_last_green` and the matrixed `bcr_presubmit` jobs to use `soft_fail`. Upgrades `rules_python` from 1.6.0-rc0 to 1.6.0.

Also adds the `{bcr_bazel}` value to matrixed `bcr_presubmit` job names.

### Motivation

It occurred to me that we don't want failing `bcr_presubmit` jobs for Bazel `8.x`, `rolling`, or `last_green` to potentially block pull requests. Breakages under these versions could be due to unrelated upstream Bazel changes, addressable in a separate pull request.

Also, the `test_rules_scala_linux_last_green` build step using `buildkite-agent annotate` doesn't fit the `bcr_presubmit` jobs well. These annotations were also somewhat easy to miss, leading to the `test_rules_scala_linux_last_green` job occasionally remaining broken for some time.

Today I learned about the `soft_fail` attribute of Buildkite commands, discovering it by skimming the `bazelbuild/continuous-integration` source. `soft_fail`ing jobs clearly show as broken in the UI, while the build as a whole remains passing.

- https://github.com/bazelbuild/continuous-integration/blob/3021432ab2403d7a660229d3ef4e1cf5c0e5c64c/buildkite/bazelci.py#L2905
- https://buildkite.com/docs/pipelines/configure/step-types/command-step#soft-fail-attributes
- https://buildkite.com/resources/changelog/56-command-steps-can-now-be-made-to-soft-fail/

Regarding the `rules_python` update, it was just released a day after opening and merging #1767.

Adding `{bcr_bazel}` to the matrixed `bcr_presubmit` job names makes each job more easily distinguishable in the Buildkite UI. Each job's output clearly shows its corresponding Bazel version, but it's nice to see the version in the job name directly.