### PR TITLE
Pass `jvm_flags` through `scala_benchmark_jmh`

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -117,5 +117,5 @@ def scala_benchmark_jmh(**kw):
         testonly = testonly,
         unused_dependency_checker_mode = "off",
         runtime_jdk = runtime_jdk,
-        jvm_flags = jvm_flags
+        jvm_flags = jvm_flags,
     )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -67,6 +67,7 @@ def scala_benchmark_jmh(**kw):
     testonly = kw.get("testonly", False)
     scalacopts = kw.get("scalacopts", [])
     main_class = kw.get("main_class", "org.openjdk.jmh.Main")
+    jvm_flags = kw.get("jvm_flags", [])
     runtime_jdk = kw.get(
         "runtime_jdk",
         "@rules_java//toolchains:current_java_runtime",
@@ -116,4 +117,5 @@ def scala_benchmark_jmh(**kw):
         testonly = testonly,
         unused_dependency_checker_mode = "off",
         runtime_jdk = runtime_jdk,
+        jvm_flags = jvm_flags
     )


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Passes `jvm_flags` through `scala_benchmark_jmh`.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
JVM flags can sometimes be necessary to run a java program (for example, when it depends on a library that needs `--add-opens`). Without passing it through to `scala_binary`, there's no way to accomplish this for a benchmark.