### PR TITLE
TEMP: probe K=4 parallel nested output bases (throwaway, do not merge)

### DIFF
--- a/test/expect_build_failure/nested_bazel.sh
+++ b/test/expect_build_failure/nested_bazel.sh
@@ -102,7 +102,7 @@ nested_bazel_setup() {
   # lock), keyed by a stable hash of the test target, so they run in parallel
   # instead of serializing on one shared lock. The shared --disk_cache (below)
   # lets the lanes reuse each other's compiled actions, bounding the extra cost.
-  local lanes=4
+  local lanes=2
   local lane=0
   if [[ -n "${TEST_TARGET:-}" ]]; then
     lane=$(( $(printf '%s' "${TEST_TARGET}" | cksum | cut -d' ' -f1) % lanes ))

--- a/test/expect_build_failure/nested_bazel.sh
+++ b/test/expect_build_failure/nested_bazel.sh
@@ -98,7 +98,16 @@ nested_bazel_setup() {
   local parent_output_base
   parent_output_base="$(_nested_bazel_find_parent_output_base)"
 
-  _nested_bazel_output_base="/tmp/${output_base_name}"
+  # PROBE: spread nested invocations across K output bases (each with its own
+  # lock), keyed by a stable hash of the test target, so they run in parallel
+  # instead of serializing on one shared lock. The shared --disk_cache (below)
+  # lets the lanes reuse each other's compiled actions, bounding the extra cost.
+  local lanes=4
+  local lane=0
+  if [[ -n "${TEST_TARGET:-}" ]]; then
+    lane=$(( $(printf '%s' "${TEST_TARGET}" | cksum | cut -d' ' -f1) % lanes ))
+  fi
+  _nested_bazel_output_base="/tmp/${output_base_name}_lane${lane}"
   mkdir -p "${_nested_bazel_output_base}"
   cd "${NESTED_BAZEL_WORKSPACE}"
 
@@ -123,6 +132,9 @@ nested_bazel_setup() {
   # Keep the nested build's convenience symlinks out of the workspace so they do
   # not clobber the parent invocation's `bazel-bin` etc.
   _nested_bazel_common_opts+=("--symlink_prefix=${_nested_bazel_output_base}/convenience_symlinks/")
+  # PROBE: shared across all lanes so parallel output bases reuse each other's
+  # compiled actions instead of each redoing the toolchain build.
+  _nested_bazel_common_opts+=("--disk_cache=/tmp/${output_base_name}_disk_cache")
 }
 
 # Runs `bazel <subcommand> [args...]` against the nested output base, inserting


### PR DESCRIPTION
Throwaway, do not merge. Probing the fix for the nested-test timeouts (#1884, #1885): the ~45 `expect_build_*_test` targets all share one nested output base, so under `bazel test //...` they serialize on a single lock and the slow ones hit the 900s timeout. This spreads them across 4 output bases (keyed by a hash of the test target) with a shared `--disk_cache`, so they run in parallel. Locally a 13-test cross-package set went 730s serial to 80s. Watching whether CI clears the timeouts and how much /tmp it uses (~1.4G per lane).
