### PR TITLE
fix: Run nested expect-test builds in parallel output bases to avoid timeouts

### DIFF
--- a/test/expect_build_failure/nested_bazel.sh
+++ b/test/expect_build_failure/nested_bazel.sh
@@ -98,7 +98,19 @@ nested_bazel_setup() {
   local parent_output_base
   parent_output_base="$(_nested_bazel_find_parent_output_base)"
 
-  _nested_bazel_output_base="/tmp/${output_base_name}"
+  # Under `bazel test //...` these nested `bazel` invocations would all contend
+  # for a single output base's lock and serialize. Spread them across a few bases,
+  # keyed by a stable hash of the test target, so they run in parallel.
+  local lanes=2
+  local lane=0
+  if [[ -n "${TEST_TARGET:-}" ]]; then
+    # Pick the lane by a cheap stable hash of the target: cksum prints
+    # "<CRC32> <byte count>", so take the CRC and reduce it modulo the lane count.
+    local target_crc
+    target_crc="$(printf '%s' "${TEST_TARGET}" | cksum | cut -d' ' -f1)"
+    lane=$((target_crc % lanes))
+  fi
+  _nested_bazel_output_base="/tmp/${output_base_name}_lane${lane}"
   mkdir -p "${_nested_bazel_output_base}"
   cd "${NESTED_BAZEL_WORKSPACE}"
 
@@ -123,6 +135,9 @@ nested_bazel_setup() {
   # Keep the nested build's convenience symlinks out of the workspace so they do
   # not clobber the parent invocation's `bazel-bin` etc.
   _nested_bazel_common_opts+=("--symlink_prefix=${_nested_bazel_output_base}/convenience_symlinks/")
+  # Shared across the lanes so they reuse each other's compiled actions instead of
+  # each rebuilding the toolchain from scratch.
+  _nested_bazel_common_opts+=("--disk_cache=/tmp/${output_base_name}_disk_cache")
 }
 
 # Runs `bazel <subcommand> [args...]` against the nested output base, inserting


### PR DESCRIPTION
### Description

Every `expect_build_*_test` / `expect_test_*_test` runs a nested `bazel build/test`, and they all shared one nested output base under /tmp. Under `bazel test //...` those nested invocations serialize on that base's lock (you can see "Another command holds the client lock ... Waiting" in the test logs), so the slow ones queue behind each other and can hit the 900s test timeout. That looks like the cause of the flaky timeouts in #1884 and #1885.

This spreads the nested invocations across a small number of output bases, keyed by a stable hash of the test target, so they run in parallel, plus a shared `--disk_cache` so the lanes reuse each other's compiled actions instead of each rebuilding the toolchain.

I went with two lanes. In the CI runs I checked, the tests that had been timing out passed (`scala_junit_test:specs2_exception_terminates_without_timeout`, `jmh/reports_failure:jmh_reports_failure_build_test`, `scala_test_testfilter:testfilter_class_selection`). But these timeouts are flaky, so I can't claim two lanes always clears them; if they come back, raising the lane count is a one-line change. Each lane is a full nested output base (roughly 1.4G in /tmp on the agents I saw, mostly JDK toolchains), so I kept the count low to bound disk.

### Motivation

Meant to address #1884 and #1885. Given how flaky these timeouts are, I'd rather confirm over a few runs before we call them closed.
