### PR TITLE
fix: return struct from write_executable phase so jacoco_metadata.txt lands in runfiles

### DIFF
--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -151,7 +151,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
             },
             is_executable = True,
         )
-        return [jacoco_metadata_file]
+        return struct(runfiles = depset([jacoco_metadata_file]))
     else:
         # RUNPATH is defined here:
         # https://github.com/bazelbuild/bazel/blob/0.4.5/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt#L227


### PR DESCRIPTION
Fixes #1892

## Root cause

`_write_executable_non_windows` returned `[jacoco_metadata_file]` (a plain Python list) from the Jacoco coverage branch. In `api.bzl`, `run_phases` stores each phase result by name into `global_provider`, so `p.write_executable` ended up being a bare list.

`phase_default_info` iterates over all phase results and only collects runfiles from results that have a `runfiles` attribute (`hasattr(phase, "runfiles")`). A plain list has no such attribute, so `jacoco_metadata.txt` was silently dropped from the test's runfiles tree.

At execution time the stub script sets:
```
JACOCO_METADATA_JAR="$JAVA_RUNFILES/<workspace>/<path>/test.jacoco_metadata.txt"
```
but that path does not exist in the sandbox. `JacocoCoverageRunner` finds no metadata, skips all instrumented classes, and writes empty coverage output.

## Fix

Return `struct(runfiles = depset([jacoco_metadata_file]))` instead of `[jacoco_metadata_file]`, matching the pattern used by every other phase that contributes files to runfiles (e.g. `phase_runfiles`, `phase_scalafmt`).

## Testing

Existing coverage tests in `test/shell/test_coverage_scalatest.sh` and `test/shell/test_scala_jacocorunner.sh` cover this path. The fix makes `jacoco_metadata.txt` appear in the runfiles tree so `JACOCO_METADATA_JAR` resolves correctly and coverage data is recorded.