### PR TITLE
TEMP: probe custom-resource gating for nested tests (do not merge)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,4 +39,8 @@ build --java_runtime_version=17
 
 #Windows needs --worker_quit_after_build due to workers not being shut down when the compiler tools need to be rebuilt (resulting in 'file in use' errors). See Bazel Issue#10498.
 
-build:windows --worker_quit_after_build --enable_runfiles 
+build:windows --worker_quit_after_build --enable_runfiles
+
+# EXPERIMENT (do not merge): declare a custom resource so the nested expect_*
+# tests tagged `resources:bazel_instance:1` run at most one at a time.
+test --local_extra_resources=bazel_instance=1 

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -132,7 +132,10 @@ def _nested_bazel_test(
         srcs = [_HELPER],
         args = args,
         data = deduped_data,
-        tags = tags,
+        # EXPERIMENT (do not merge): gate how many nested tests run at once via a
+        # custom resource instead of `exclusive`, so the queue wait sits in the
+        # scheduler (not against each test's timeout) while keeping one output base.
+        tags = tags + ["resources:bazel_instance:1"],
         **kwargs
     )
 


### PR DESCRIPTION
Throwaway probe, do not merge. Tests the resource-gating idea from #1891 (cap nested tests to one at a time via `--local_extra_resources`, single output base) and prints the agent disk/spec.