### PR TITLE
fix: Fail no_sigs.sh when the jar lister cannot read the jar

### DIFF
--- a/test/sh_tests/BUILD
+++ b/test/sh_tests/BUILD
@@ -128,7 +128,7 @@ genrule(
     name = "fake_signed_jar",
     srcs = ["fake_signature.txt"],
     outs = ["fake_signed.jar"],
-    cmd = "$(location @bazel_tools//tools/zip:zipper) c $@ META-INF/FOO.RSA=$(location fake_signature.txt)",
+    cmd = "$(execpath @bazel_tools//tools/zip:zipper) c $@ META-INF/FOO.RSA=$(execpath fake_signature.txt)",
     tools = ["@bazel_tools//tools/zip:zipper"],
 )
 

--- a/test/sh_tests/BUILD
+++ b/test/sh_tests/BUILD
@@ -124,6 +124,29 @@ sh_test(
     ],
 )
 
+genrule(
+    name = "fake_signed_jar",
+    srcs = ["fake_signature.txt"],
+    outs = ["fake_signed.jar"],
+    cmd = "$(location @bazel_tools//tools/zip:zipper) c $@ META-INF/FOO.RSA=$(location fake_signature.txt)",
+    tools = ["@bazel_tools//tools/zip:zipper"],
+)
+
+sh_test(
+    name = "no_sig_required_failures",
+    srcs = ["no_sigs_required_failures.sh"],
+    args = [
+        "$(rootpath no_sigs.sh)",
+        "$(rootpath :jar_lister)",
+        "$(rootpath :fake_signed_jar)",
+    ],
+    data = [
+        "no_sigs.sh",
+        ":fake_signed_jar",
+        ":jar_lister",
+    ],
+)
+
 py_binary(
     name = "py_resource_binary",
     srcs = ["py_resource.py"],

--- a/test/sh_tests/fake_signature.txt
+++ b/test/sh_tests/fake_signature.txt
@@ -1,0 +1,2 @@
+Filler for a jar entry named META-INF/*.RSA. A real signature block is PKCS#7;
+no_sigs.sh only looks at entry names, so the content never matters.

--- a/test/sh_tests/no_sigs.sh
+++ b/test/sh_tests/no_sigs.sh
@@ -1,13 +1,19 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-OUTPUT1=`$1 $2 | grep DSA`
-OUTPUT2=`$1 $2 | grep RSA`
+set -euo pipefail
 
-if [[ $OUTPUT1 ]]; then
-  echo $OUTPUT1
+lister="$1"
+jar="$2"
+
+# A listing that never got produced looks the same as a jar without signature
+# files, so a lister that failed would pass this test for free.
+if ! listing="$("${lister}" "${jar}")" ; then
+  echo "ERROR: Could not list ${jar}." >&2
   exit 1
 fi
-if [[ $OUTPUT2 ]]; then
-  echo $OUTPUT2
+
+if signatures="$(grep -E 'DSA|RSA' <<<"${listing}")" ; then
+  echo "ERROR: Found signature files in ${jar}:" >&2
+  echo "${signatures}" >&2
   exit 1
 fi

--- a/test/sh_tests/no_sigs.sh
+++ b/test/sh_tests/no_sigs.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 
 lister="$1"
-jar="$2"
+# The py_binary launcher does not run with the test's working directory on
+# Windows, so a rootpath argument has to be made absolute before it is passed on.
+jar="${TEST_SRCDIR:-${RUNFILES_DIR:-$0.runfiles}}/${TEST_WORKSPACE:-_main}/$2"
 
 # A listing that never got produced looks the same as a jar without signature
 # files, so a lister that failed would pass this test for free.

--- a/test/sh_tests/no_sigs_required_failures.sh
+++ b/test/sh_tests/no_sigs_required_failures.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script="$1"
+lister="$2"
+signed_jar="$3"
+
+expect_rejected() {
+  local jar="$1" expected="$2" output
+
+  if output="$("${script}" "${lister}" "${jar}" 2>&1)" ; then
+    echo "ERROR: ${script} accepted ${jar}. Output: ${output}" >&2
+    exit 1
+  fi
+
+  if ! grep -q "${expected}" <<<"${output}" ; then
+    echo "ERROR: ${script} rejected ${jar}, but not with \"${expected}\". Output: ${output}" >&2
+    exit 1
+  fi
+}
+
+expect_rejected does_not_exist.jar 'Could not list'
+expect_rejected "${signed_jar}" 'Found signature files'

--- a/test/sh_tests/no_sigs_required_failures.sh
+++ b/test/sh_tests/no_sigs_required_failures.sh
@@ -9,7 +9,7 @@ signed_jar="$3"
 expect_rejected() {
   local jar="$1" expected="$2" output
 
-  if output="$("${script}" "${lister}" "${jar}" 2>&1)" ; then
+  if output="$(bash "${script}" "${lister}" "${jar}" 2>&1)" ; then
     echo "ERROR: ${script} accepted ${jar}. Output: ${output}" >&2
     exit 1
   fi


### PR DESCRIPTION
### Description

`no_sigs.sh` ran the jar lister twice and only looked at whether the output held `DSA` or `RSA`. `jar_lister.py` is four lines with no error handling: on a jar it cannot open it raises, exits 1 and prints nothing to stdout. Both captures came out empty, both `if`s were skipped, and the test exited 0. The assertion here is about absence, so the target that guards against signature files leaking into a deploy jar reported success exactly when it could not read the jar.

The script now captures the listing once and exits 1 if the lister did not succeed, using the same message as #1897 so both tests fail the same way. The two greps became a single `grep -E 'DSA|RSA'` over the captured listing, same outcome. The failure branch also says what it found instead of printing a bare path.

The shebang said `#!/bin/sh` while the body used `[[ ]]`, a bash builtin. It worked because Bazel runs `sh_test` through bash. It now says `#!/usr/bin/env bash`, like the other scripts in this package. #1897 keeps `#!/bin/sh` because that script is POSIX for real.

This also turned up a second instance of the same bug in the target it fixes. On Windows `no_sig` was green while the lister never read the jar at all: the py_binary launcher does not run with the test's working directory there, so the relative `rootpath` argument did not resolve, and an empty listing looked exactly like a jar with no signature files. The fix made that visible, both targets failed on the Windows step with `FileNotFoundError: 'test/ScalaBinary_with_fake_deploy.jar'`, so the jar path is now resolved against `TEST_SRCDIR` the way `test/macros/expect_no_ijar.sh` and `test/expect_build_failure/expect_build_failure.sh` do it. Checked locally on macOS, and the Windows step passes with it.

`no_sig_required_failures` covers the two inputs `no_sigs.sh` has to reject: a jar path that does not exist, and a fixture jar holding a `META-INF/FOO.RSA` entry, built with `zipper` the way `test/java_in_src_jar` does. For each it asserts both a non-zero exit and the matching message. I checked all three ways it can go red: the old script fails it, so does a version that prints `Could not list` but drops the `exit 1` (which a message-only check would let through), and so does a version with the `DSA|RSA` predicate neutered. It also passes under each of the three `--extra_toolchains` overrides `test_rules_scala.sh` applies to `test/...`.

One thing I left alone: the predicate stays as broad as it was. `DSA|RSA` is unanchored, so it also matches something like `RSAKeys.class`, and it ignores `META-INF/*.SF`. For an absence check the broad direction is the safe one, so tightening it would make the test quieter, not better.

### Motivation

Same class of bug as #1897: a test that stays quiet when its tool never ran reports success it never checked. On Linux and macOS the lister could always read the jar, so those steps behave as before. Windows is the one place where it could not, which is what the path fix above is for.
