### PR TITLE
test: Declare the inputs of the nested expect_* tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,3 +7,12 @@ exports_files(["MODULE.bazel"])
 # repo rule's generated output; listing it in that test's `data` re-keys the test
 # when the generation logic changes.
 exports_files(["scala_config.bzl"])
+
+# Declared inputs of the nested `bazel` tests: it reads the repo `.bazelrc`,
+# resolves dependencies from the lock and runs the version bazelisk picks, so
+# all three decide their outcome. See //test/expect_build_failure.
+exports_files([
+    ".bazelrc",
+    ".bazelversion",
+    "MODULE.bazel.lock",
+])

--- a/test/BUILD
+++ b/test/BUILD
@@ -29,6 +29,7 @@ package(
         "//test/repl:__pkg__",
         "//test/rootpaths:__pkg__",
         "//test/scala_junit_test:__pkg__",
+        "//test/scala_test_testfilter:__pkg__",
     ],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -29,7 +29,6 @@ package(
         "//test/repl:__pkg__",
         "//test/rootpaths:__pkg__",
         "//test/scala_junit_test:__pkg__",
-        "//test/scala_test_testfilter:__pkg__",
     ],
 )
 
@@ -153,6 +152,7 @@ scala_test_suite(
 scala_test(
     name = "TestFilterTests",
     size = "small",
+    visibility = ["//test:__subpackages__"],
     srcs = glob(["TestFilterTest*.scala"]),
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -79,6 +79,7 @@ java_binary(
 
 scala_binary(
     name = "ScalaBinary",
+    visibility = ["//test:__subpackages__"],
     srcs = ["ScalaBinary.scala"],
     main_class = "scalarules.test.ScalaBinary",
     print_compile_time = True,
@@ -196,6 +197,7 @@ scala_library(
 
 scala_library(
     name = "UnusedDependencyCheckerWarn",
+    visibility = ["//test:__subpackages__"],
     srcs = ["OtherLib.scala"],
     unused_dependency_checker_mode = "warn",
     deps = [

--- a/test/classpath_resource_conflict/BUILD
+++ b/test/classpath_resource_conflict/BUILD
@@ -9,9 +9,8 @@ package(default_testonly = 1)
 # expect_build_success_test and assert the warning is surfaced. (See that macro's
 # docstring for how it keeps a cached action from hiding the warning.)
 #
-# `target` lives in another package, so its sources aren't tracked as this test's
-# runfiles (see expect_build_failure.bzl) and an edit there won't force a re-run;
-# the fixture is long-standing and rarely touched.
+# `target` lives in another package, so the macro tags this test `external`
+# (see expect_build_failure.bzl) and it re-runs on every invocation.
 expect_build_success_test(
     name = "classpath_resource_namespace_conflict_test",
     expect = ["expected_namespace_conflict.txt"],

--- a/test/classpath_resource_conflict/BUILD
+++ b/test/classpath_resource_conflict/BUILD
@@ -9,9 +9,8 @@ package(default_testonly = 1)
 # expect_build_success_test and assert the warning is surfaced. (See that macro's
 # docstring for how it keeps a cached action from hiding the warning.)
 #
-# `target` lives in another package, but it's one concrete label, so the macro
-# still fingerprints it via `fixture_actions` (see expect_build_failure.bzl)
-# instead of tagging this test `external`.
+# `target` lives in another package; see expect_build_failure.bzl's docstring
+# for why that still gets a real fingerprint here.
 expect_build_success_test(
     name = "classpath_resource_namespace_conflict_test",
     expect = ["expected_namespace_conflict.txt"],

--- a/test/classpath_resource_conflict/BUILD
+++ b/test/classpath_resource_conflict/BUILD
@@ -9,8 +9,9 @@ package(default_testonly = 1)
 # expect_build_success_test and assert the warning is surfaced. (See that macro's
 # docstring for how it keeps a cached action from hiding the warning.)
 #
-# `target` lives in another package, so the macro tags this test `external`
-# (see expect_build_failure.bzl) and it re-runs on every invocation.
+# `target` lives in another package, but it's one concrete label, so the macro
+# still fingerprints it via `fixture_actions` (see expect_build_failure.bzl)
+# instead of tagging this test `external`.
 expect_build_success_test(
     name = "classpath_resource_namespace_conflict_test",
     expect = ["expected_namespace_conflict.txt"],

--- a/test/community_build/downstream_test_driver.sh
+++ b/test/community_build/downstream_test_driver.sh
@@ -107,6 +107,11 @@ parent_output_base="$(_nested_bazel_find_parent_output_base)"
 _nested_bazel_output_base="/tmp/${output_base_name}"
 mkdir -p "${_nested_bazel_output_base}"
 cd "${NESTED_BAZEL_WORKSPACE}"
+# This driver always uses the developer's home directory. `nested_bazel_setup`
+# does so only when asked, because a `~/.bazelrc` outside the repo could then
+# decide the result of a test whose pass is cached and reused. The tests here
+# are tagged `external`, so Bazel re-runs them every time and there is no such
+# stale pass to worry about. The paths built below need a home directory anyway.
 _nested_bazel_real_home="$(eval echo "~$(id -un)" 2>/dev/null || true)"
 _nested_bazel_common_opts=()
 repository_cache="$(dirname "${parent_output_base}")/cache/repos/v1"

--- a/test/expect_build_failure/README.md
+++ b/test/expect_build_failure/README.md
@@ -1,0 +1,77 @@
+# Asserting that a build or a test fails
+
+Two mechanisms live here. Pick by *when* the failure happens.
+
+## Analysis-time failure: use `expect_analysis_failure_test`
+
+A target that Bazel rejects while analysing it -- a `fail()` in a rule, a bad
+attribute combination -- needs no build at all. `expect_analysis_failure_test`
+(see `expect_analysis_failure.bzl`) asks Bazel in-process through
+`bazel_skylib`'s `analysistest`. It is hermetic, cacheable and runs in under a
+second.
+
+## Execution-time failure: use the `expect_*` macros
+
+A compile error, a failing test binary, a warning printed by an action: these
+only appear once actions run, and Bazel has no native rule for "run a build and
+assert it fails". So `expect_build_failure.bzl` wraps an `sh_test` around a
+**nested `bazel`** invocation.
+
+That nested build reads the real source tree, which the outer Bazel cannot see,
+so the test has to declare by hand everything that decides its outcome. The
+macro does that for you; the docstring in `expect_build_failure.bzl` lists what
+goes into the cache key and what stays outside it.
+
+Nothing re-runs these tests without the result cache on a schedule. That would be
+the way to catch an input nobody thought to declare.
+
+## What to delete later
+
+- **On Bazel 8 or newer**, an aspect can reach toolchain dependencies through
+  `aspect(toolchains_aspects = ...)`. That replaces `_SCALAC_JAR` and
+  `_RUNNER_JARS`, which exist only because the fingerprint carries the tools'
+  paths and not their content. This repo pins 7.7.1 in `.bazelversion`, where
+  the parameter does not exist.
+- **The success cases do not need a nested build at all.** A Starlark transition
+  can set `//command_line_option:extra_toolchains`, verified on Bazel 7.7.1: the
+  same fixture fails with the `-Xmx1M` toolchain and builds with the `-Xmx1G` one
+  when the flag is set that way. Of the 61 tests here, 41 assert a failure and do
+  need the nested build, because a target that fails cannot be a dependency. The
+  other 20 assert success: 17 of those only set flags and check nothing about the
+  output, so a transition plus `build_test` covers them, and 1 sets no flags at
+  all and needs only `build_test`. The last 2 assert on build output, which only
+  a real invocation produces. Those 18 took 180s of the 653s a full local run
+  spends here, all of it on the critical path because of `exclusive`.
+- **The whole nested driver** would go away by moving these tests to
+  [`rules_bazel_integration_test`](https://github.com/bazel-contrib/rules_bazel_integration_test),
+  which gives each test its own child workspace and an explicit `workspace_files`
+  attribute. Then the inputs are declared by construction rather than by hand,
+  the shared output base disappears, and with it the `exclusive` tag that
+  serialises these tests today. The cost is moving 27 fixture packages into
+  child workspaces, so it is a project rather than a patch.
+
+## When you add a test here
+
+Nothing in a caller has to know about caching. Two things are worth knowing:
+
+- If the fixture lives in another package, make it visible to yours; the
+  fingerprint is a real dependency edge, unlike the label string the nested
+  `bazel` receives.
+- A nested build runs with a scrubbed `HOME`, so your `~/.bazelrc` is ignored.
+  If you need it (a download proxy, say), set
+  `RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1`. Any failing nested build says so.
+
+## Registering a toolchain
+
+A toolchain the nested build registers decides whether that build fails, and it
+is not part of the fixture's own graph. The macro handles this on its own: it
+reads the `--extra_toolchains` flags out of the arguments it forwards and
+analyses the fixture under exactly those toolchains, through a Starlark
+transition on `//command_line_option:extra_toolchains`. Change a toolchain and
+the command lines in the fingerprint change with it, so the test re-runs.
+
+Nothing to declare in the toolchain's package, in other words. Verified by
+setting `unused_dependency_checker_mode`, `strict_deps_mode` and
+`dependency_mode` in `//scala:minimal_direct_source_deps` to values that would
+make the assertion vacuous: each moves the fingerprint of the test that
+registers it.

--- a/test/expect_build_failure/README.md
+++ b/test/expect_build_failure/README.md
@@ -52,7 +52,7 @@ the way to catch an input nobody thought to declare.
 
 ## When you add a test here
 
-Nothing in a caller has to know about caching. Two things are worth knowing:
+Nothing in a caller has to know about caching. Three things are worth knowing:
 
 - If the fixture lives in another package, make it visible to yours; the
   fingerprint is a real dependency edge, unlike the label string the nested
@@ -60,6 +60,23 @@ Nothing in a caller has to know about caching. Two things are worth knowing:
 - A nested build runs with a scrubbed `HOME`, so your `~/.bazelrc` is ignored.
   If you need it (a download proxy, say), set
   `RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1`. Any failing nested build says so.
+- Analysis fails if the fingerprint carries no rules_scala action, because such
+  a fingerprint cannot notice a change in the rules and the test it keys would
+  stay green through a regression. Either point `fingerprint_target` at a label
+  the nested build really compiles, or say why you cannot with
+  `no_fingerprint_reason`, which tags the test `external` so it re-runs every
+  time rather than being served a pass it cannot vouch for. Seven tests do that
+  today: `scala_proto` generates through an aspect of its own, whose actions
+  this aspect cannot read, and the `semanticdb` fixtures only build toolchain
+  deps, so they compile nothing at all.
+
+What the fingerprint does not see: an action that writes a file instead of
+running a command line (`ctx.actions.write`, template expansion) contributes its
+mnemonic and nothing else, which is 446 of the 5135 lines it collects today. A
+change to what such an action writes leaves the fingerprint identical. Declaring
+those files instead would put output paths -- and with them the configuration --
+back into the key, which is what makes the tests re-run under every flag the
+outer build sets.
 
 ## Registering a toolchain
 

--- a/test/expect_build_failure/README.md
+++ b/test/expect_build_failure/README.md
@@ -54,12 +54,13 @@ the way to catch an input nobody thought to declare.
 
 Nothing in a caller has to know about caching. Three things are worth knowing:
 
-- If the fixture lives in another package, make it visible to yours; the
-  fingerprint is a real dependency edge, unlike the label string the nested
-  `bazel` receives.
+- If the fixture lives in another package, the macro tags the test `external`,
+  because it cannot verify that caller data covers every source the nested target
+  reads.
 - A nested build runs with a scrubbed `HOME`, so your `~/.bazelrc` is ignored.
-  If you need it (a download proxy, say), set
-  `RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1`. Any failing nested build says so.
+  If you need it (a download proxy, say), pass `--nocache_test_results` and
+  `--test_env=RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1` to `bazel test`. The
+  home file is outside this test's key, so keep this opt-in uncached.
 - Analysis fails if the fingerprint carries no rules_scala action, because such
   a fingerprint cannot notice a change in the rules and the test it keys would
   stay green through a regression. Either point `fingerprint_target` at a label

--- a/test/expect_build_failure/README.md
+++ b/test/expect_build_failure/README.md
@@ -79,11 +79,16 @@ Nothing in a caller has to know about caching. Three things are worth knowing:
 
 What the fingerprint does not see: an action that writes a file instead of
 running a command line (`ctx.actions.write`, template expansion) contributes its
-mnemonic and nothing else, which is 446 of the 5135 lines it collects today. A
-change to what such an action writes leaves the fingerprint identical. Declaring
-those files instead would put output paths -- and with them the configuration --
-back into the key, which is what makes the tests re-run under every flag the
-outer build sets.
+mnemonic and nothing else, so a change to what such an action writes leaves the
+fingerprint identical. The same blind spot applies more broadly: an action's
+command line carries a file's path, not its content, so a content-only change
+to a file rules_scala itself reads by path (rather than compiles from a
+fixture's own sources) also leaves the fingerprint identical -- `_SCALAC_JAR`
+and `_RUNNER_JARS` below are declared as explicit `data` for exactly this
+reason. Declaring the file such a write action produces as a test input
+instead would put its output path -- and with it the configuration -- back
+into the key, which is what makes the tests re-run under every flag the outer
+build sets.
 
 ## Registering a toolchain
 

--- a/test/expect_build_failure/README.md
+++ b/test/expect_build_failure/README.md
@@ -32,16 +32,16 @@ the way to catch an input nobody thought to declare.
   `_RUNNER_JARS`, which exist only because the fingerprint carries the tools'
   paths and not their content. This repo pins 7.7.1 in `.bazelversion`, where
   the parameter does not exist.
-- **The success cases do not need a nested build at all.** A Starlark transition
-  can set `//command_line_option:extra_toolchains`, verified on Bazel 7.7.1: the
-  same fixture fails with the `-Xmx1M` toolchain and builds with the `-Xmx1G` one
-  when the flag is set that way. Of the 61 tests here, 41 assert a failure and do
-  need the nested build, because a target that fails cannot be a dependency. The
-  other 20 assert success: 17 of those only set flags and check nothing about the
-  output, so a transition plus `build_test` covers them, and 1 sets no flags at
-  all and needs only `build_test`. The last 2 assert on build output, which only
-  a real invocation produces. Those 18 took 180s of the 653s a full local run
-  spends here, all of it on the critical path because of `exclusive`.
+- **Most success cases do not need a nested build at all.** A Starlark
+  transition can set `//command_line_option:extra_toolchains`, verified on
+  Bazel 7.7.1: the same fixture fails with the `-Xmx1M` toolchain and builds
+  with the `-Xmx1G` one when the flag is set that way. A test asserting a
+  build *failure* still needs the nested build, because a target that fails
+  cannot be a dependency. A test asserting *success* only needs it if it also
+  checks the build output (`expect`/`reject`); one that just checks the build
+  passed under a flag or toolchain override can be replaced with a transition
+  plus `build_test`, which runs in-process and isn't `exclusive`, so it drops
+  off the critical path these nested tests share today.
 - **The whole nested driver** would go away by moving these tests to
   [`rules_bazel_integration_test`](https://github.com/bazel-contrib/rules_bazel_integration_test),
   which gives each test its own child workspace and an explicit `workspace_files`
@@ -68,10 +68,14 @@ Nothing in a caller has to know about caching. Three things are worth knowing:
   stay green through a regression. Either point `fingerprint_target` at a label
   the nested build really compiles, or say why you cannot with
   `no_fingerprint_reason`, which tags the test `external` so it re-runs every
-  time rather than being served a pass it cannot vouch for. Seven tests do that
-  today: `scala_proto` generates through an aspect of its own, whose actions
-  this aspect cannot read, and the `semanticdb` fixtures only build toolchain
-  deps, so they compile nothing at all.
+  time rather than being served a pass it cannot vouch for. A few tests do
+  that today, for one of four reasons: `scala_proto` generates through an
+  aspect of its own, whose actions this aspect cannot read; the `semanticdb`
+  fixtures only build toolchain deps, so they compile nothing at all; a
+  fixture targets a plain `proto_library`/`java_library`, which runs no
+  rules_scala action either; or fingerprinting two fixtures under the same
+  `--extra_toolchains` would analyse a shared dependency under two different
+  aspect stacks, which Bazel reports as an `ActionConflictException`.
 
 What the fingerprint does not see: an action that writes a file instead of
 running a command line (`ctx.actions.write`, template expansion) contributes its

--- a/test/expect_build_failure/README.md
+++ b/test/expect_build_failure/README.md
@@ -54,9 +54,11 @@ the way to catch an input nobody thought to declare.
 
 Nothing in a caller has to know about caching. Three things are worth knowing:
 
-- If the fixture lives in another package, the macro tags the test `external`,
-  because it cannot verify that caller data covers every source the nested target
-  reads.
+- If the fixture lives in another package, it still gets a real fingerprint
+  through `fixture_actions` when `target` is one concrete label. Only a
+  cross-package *pattern* (a wildcard like `//pkg/...`) gets tagged `external`,
+  because there's no single label a macro could fingerprint or a caller could
+  declare as `data`.
 - A nested build runs with a scrubbed `HOME`, so your `~/.bazelrc` is ignored.
   If you need it (a download proxy, say), pass `--nocache_test_results` and
   `--test_env=RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1` to `bazel test`. The

--- a/test/expect_build_failure/collect_actions.bzl
+++ b/test/expect_build_failure/collect_actions.bzl
@@ -35,7 +35,7 @@ def _without_configuration(line):
         out += "bazel-out/" + ("<cfg>" + part[slash:] if slash != -1 else part)
     return out
 
-def _collect_impl(target, ctx):
+def _collect_actions_aspect_impl(target, ctx):
     # One line per action, joining mnemonic and argv so each action keeps its own
     # flag-to-value pairing. Collecting individual tokens into one depset would
     # lose that pairing: several rules_scala flags share the same "off"/"warn"/
@@ -59,7 +59,7 @@ def _collect_impl(target, ctx):
     return [_ActionsInfo(lines = depset(direct, transitive = transitive))]
 
 collect_actions_aspect = aspect(
-    implementation = _collect_impl,
+    implementation = _collect_actions_aspect_impl,
     attr_aspects = ["*"],
 )
 

--- a/test/expect_build_failure/collect_actions.bzl
+++ b/test/expect_build_failure/collect_actions.bzl
@@ -29,15 +29,19 @@ def _without_configuration(line):
     out = parts[0]
     for part in parts[1:]:
         slash = part.find("/")
+        # No slash means the token ends right at the configuration directory (no
+        # path below it), so there's nothing to anchor the replacement on; leave
+        # it as-is rather than guess where the configuration name ends.
         out += "bazel-out/" + ("<cfg>" + part[slash:] if slash != -1 else part)
     return out
 
 def _collect_impl(target, ctx):
-    # One line per action, keeping the arguments in order. Collecting the tokens
-    # separately would lose which value belongs to which flag: a depset of tokens
-    # does not change when a flag's value is swapped for one that some other flag
-    # already carries, and `unused_dependency_checker_mode = "error"` -> `"off"`
-    # is exactly that.
+    # One line per action, joining mnemonic and argv so each action keeps its own
+    # flag-to-value pairing. Collecting individual tokens into one depset would
+    # lose that pairing: several rules_scala flags share the same "off"/"warn"/
+    # "error" values (e.g. unused_dependency_checker_mode and strict_deps_mode),
+    # so moving a value from one such flag to another leaves the flat set of
+    # tokens unchanged even though the actual behavior changed.
     direct = []
     for action in target.actions:
         argv = getattr(action, "argv", None) or []
@@ -76,7 +80,7 @@ _toolchains_transition = transition(
 # without it describes a target the rules never touch.
 _RULESET_TOOLS = "src/java/io/bazel/rulesscala"
 
-def _exposed_impl(ctx):
+def _fixture_actions_impl(ctx):
     lines = sorted(ctx.attr.target[0][_ActionsInfo].lines.to_list())
     if not [line for line in lines if _RULESET_TOOLS in line]:
         fail(("%s runs no rules_scala action, so it cannot tell whether the rules " +
@@ -89,7 +93,7 @@ def _exposed_impl(ctx):
     return [DefaultInfo(files = depset([out]))]
 
 fixture_actions = rule(
-    implementation = _exposed_impl,
+    implementation = _fixture_actions_impl,
     attrs = {
         "extra_toolchains": attr.string_list(
             doc = "Toolchains the nested `bazel` registers, to analyse `target` under.",

--- a/test/expect_build_failure/collect_actions.bzl
+++ b/test/expect_build_failure/collect_actions.bzl
@@ -1,0 +1,91 @@
+"""Serializes the actions a target would run, so they can key a nested test.
+
+A nested `bazel build` is opaque to the outer Bazel, so a change in the rules
+that alters how the fixture is built does not invalidate the test that drives
+it. The command lines do change, though, and an aspect can read them: writing
+them to a file and declaring that file as a test input makes the test re-run
+exactly when the fixture's build actually changed.
+
+The fixture is analysed under the toolchains the nested `bazel` registers, so a
+change in one of those lands in the command lines too.
+
+Command lines carry output paths, and those name the configuration they were
+built in, so the fingerprint would otherwise differ under every flag the outer
+build happens to set and re-run the test for nothing. The configuration segment
+is dropped, in the spirit of Bazel's own path mapping. What is left out: actions
+that write a file rather than run a command line (`ctx.actions.write`, template
+expansion) contribute their mnemonic and nothing else, so a change to what such
+an action writes does not reach the fingerprint.
+"""
+
+_ActionsInfo = provider(fields = ["lines"])
+
+def _without_configuration(line):
+    # Output paths carry the configuration (`bazel-out/k8-fastbuild-ST-1234/`),
+    # so the same fixture yields a different fingerprint under every flag the
+    # outer build happens to set, and every such build re-runs the test. The
+    # nested `bazel` does not inherit those flags, so drop the segment.
+    parts = line.split("bazel-out/")
+    out = parts[0]
+    for part in parts[1:]:
+        slash = part.find("/")
+        out += "bazel-out/" + ("<cfg>" + part[slash:] if slash != -1 else part)
+    return out
+
+def _collect_impl(target, ctx):
+    # One line per action, keeping the arguments in order. Collecting the tokens
+    # separately would lose which value belongs to which flag: a depset of tokens
+    # does not change when a flag's value is swapped for one that some other flag
+    # already carries, and `unused_dependency_checker_mode = "error"` -> `"off"`
+    # is exactly that.
+    direct = []
+    for action in target.actions:
+        argv = getattr(action, "argv", None) or []
+        direct.append(_without_configuration(" ".join([action.mnemonic] + argv)))
+
+    # A fixture may compile in its dependencies rather than itself (a
+    # `scala_library_suite` builds children and only merges their jars), so the
+    # command lines that a rules change would alter live one level down.
+    transitive = []
+    for attr_name in dir(ctx.rule.attr):
+        value = getattr(ctx.rule.attr, attr_name, None)
+        for dep in (value if type(value) == "list" else [value]):
+            if type(dep) == "Target" and _ActionsInfo in dep:
+                transitive.append(dep[_ActionsInfo].lines)
+    return [_ActionsInfo(lines = depset(direct, transitive = transitive))]
+
+collect_actions_aspect = aspect(
+    implementation = _collect_impl,
+    attr_aspects = ["*"],
+)
+
+def _toolchains_transition_impl(_settings, attr):
+    # Analyse the fixture under the toolchains the nested `bazel` will register,
+    # so that changing one of them changes the command lines collected above.
+    # Whatever the outer build registered is replaced, not extended: the nested
+    # `bazel` gets these and nothing else.
+    return {"//command_line_option:extra_toolchains": attr.extra_toolchains}
+
+_toolchains_transition = transition(
+    implementation = _toolchains_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:extra_toolchains"],
+)
+
+def _exposed_impl(ctx):
+    out = ctx.actions.declare_file("%s.actions.txt" % ctx.label.name)
+    ctx.actions.write(out, content = "\n".join(
+        sorted(ctx.attr.target[0][_ActionsInfo].lines.to_list()),
+    ) + "\n")
+    return [DefaultInfo(files = depset([out]))]
+
+fixture_actions = rule(
+    implementation = _exposed_impl,
+    attrs = {
+        "extra_toolchains": attr.string_list(
+            doc = "Toolchains the nested `bazel` registers, to analyse `target` under.",
+        ),
+        "target": attr.label(aspects = [collect_actions_aspect], cfg = _toolchains_transition),
+    },
+    doc = "Writes the command lines of `target`'s actions to a file.",
+)

--- a/test/expect_build_failure/collect_actions.bzl
+++ b/test/expect_build_failure/collect_actions.bzl
@@ -72,11 +72,20 @@ _toolchains_transition = transition(
     outputs = ["//command_line_option:extra_toolchains"],
 )
 
+# Every action this ruleset runs invokes a tool built from here, so a fingerprint
+# without it describes a target the rules never touch.
+_RULESET_TOOLS = "src/java/io/bazel/rulesscala"
+
 def _exposed_impl(ctx):
+    lines = sorted(ctx.attr.target[0][_ActionsInfo].lines.to_list())
+    if not [line for line in lines if _RULESET_TOOLS in line]:
+        fail(("%s runs no rules_scala action, so it cannot tell whether the rules " +
+              "changed and the test it keys would stay green through a regression. " +
+              "Point fingerprint_target at a label the nested build really compiles, " +
+              "or state why it cannot with no_fingerprint_reason.") %
+             ctx.attr.target[0].label)
     out = ctx.actions.declare_file("%s.actions.txt" % ctx.label.name)
-    ctx.actions.write(out, content = "\n".join(
-        sorted(ctx.attr.target[0][_ActionsInfo].lines.to_list()),
-    ) + "\n")
+    ctx.actions.write(out, content = "\n".join(lines) + "\n")
     return [DefaultInfo(files = depset([out]))]
 
 fixture_actions = rule(

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -211,7 +211,7 @@ def _nested_bazel_test(
     fingerprint_target_is_pattern = "..." in fingerprint_target or fingerprint_target.endswith((":all", ":*"))
 
     if no_fingerprint_reason or (cross_package_fixture and fingerprint_target_is_pattern):
-        # The package glob above cannot cross a Bazel package boundary, and a
+        # `code_under_test` above cannot cross a Bazel package boundary, and a
         # macro cannot prove that caller `data` covers every source of a
         # pattern -- there's no single label to declare. Keep such results out
         # of the cache rather than serve a stale pass after an undeclared
@@ -240,9 +240,12 @@ def _nested_bazel_test(
         )
         data.append(":%s_fixture_actions" % name)
 
-    # `no-sandbox` rather than `local`: both run the nested `bazel` outside the
-    # sandbox, which is all it needs, but a `local` result is also kept out of
-    # the shared cache. `no-remote-exec` because it reads this machine's tree.
+    # Callers default `tags` to `no-sandbox` rather than `local`: both run the
+    # nested `bazel` outside the sandbox, which is all it needs, but a `local`
+    # result is also kept out of the shared cache. Added here: `exclusive`,
+    # because each run takes the shared output base's lock, so running them one
+    # at a time keeps them off each other's timeout; `no-remote-exec`, because
+    # this reads this machine's tree.
     execution_tags = tags + ["exclusive", "no-remote-exec"]
 
     # De-duplicate by canonical label: `code_under_test` re-lists files that are
@@ -268,9 +271,6 @@ def _nested_bazel_test(
         srcs = [_HELPER],
         args = args,
         data = deduped_data,
-        # `exclusive`: each runs a nested `bazel` that takes the shared output
-        # base's lock, so running them one at a time keeps them off each other's
-        # timeout.
         tags = execution_tags,
         **kwargs
     )

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -160,8 +160,9 @@ def _nested_bazel_test(
     # build, and a macro can't introspect a target's `srcs` anyway. So glob every
     # source file in this package and declare it as runfiles: editing any of them
     # changes the test's cache key and forces a re-run. This covers the common
-    # case of a fixture whose sources live alongside its BUILD file; a `target` in
-    # another package is tagged `external` below.
+    # case of a fixture whose sources live alongside its BUILD file; a `target`
+    # in another package either gets a real fingerprint via `fixture_actions`
+    # below or, if it's a pattern, is tagged `external`.
     code_under_test = native.glob(["**/*"], allow_empty = True)
 
     # Both entries must be in the test's runfiles (a file reaches runfiles only if

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -75,6 +75,8 @@ _SCALAC_JAR = "//src/java/io/bazel/rulesscala/scalac:scalac_deploy.jar"
 
 # The compiler jar above does not pull in the test runners, and a nested
 # `bazel test` runs through them, so their content decides its outcome too.
+# Kept in sync by hand with each rule's default runner/instrumenter dep; a new
+# one added to rules_scala needs a line here too.
 _RUNNER_JARS = [
     "//src/java/io/bazel/rulesscala/test_discovery:test_discovery.jar",
     "//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery.jar",

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -104,6 +104,7 @@ def _nested_bazel_test(
         size,
         tags,
         fingerprint_target,
+        no_fingerprint_reason,
         bazel_arg_files = [],
         **kwargs):
     args = ["--command", command, "--target", _absolutize(target)]
@@ -186,19 +187,27 @@ def _nested_bazel_test(
         if arg.startswith("--extra_toolchains=")
     ]
 
-    # `target` may be a pattern, which has no single configured target to read
-    # actions from. Rather than leave such a test without a key, ask for one
-    # concrete target the pattern builds.
-    fingerprint_target = fingerprint_target or target
-    if "..." in fingerprint_target or fingerprint_target.endswith((":all", ":*")):
-        fail("target %s is a pattern; pass fingerprint_target with one concrete label it builds, so a rules change still invalidates %s" % (target, name))
-    fixture_actions(
-        name = "%s_fixture_actions" % name,
-        target = fingerprint_target,
-        extra_toolchains = extra_toolchains,
-        testonly = True,
-    )
-    data.append(":%s_fixture_actions" % name)
+    # Some nested builds run no action this aspect can read: `scala_proto`
+    # generates through an aspect of its own, and a fixture that only builds
+    # toolchain deps compiles nothing at all. Such a test states why and is
+    # tagged `external`, which keeps it out of the cache entirely -- a test
+    # without a fingerprint must not be served a stale pass.
+    if no_fingerprint_reason:
+        tags = tags + ["external"]
+    else:
+        # `target` may be a pattern, which has no single configured target to read
+        # actions from. Rather than leave such a test without a key, ask for one
+        # concrete target the pattern builds.
+        fingerprint_target = fingerprint_target or target
+        if "..." in fingerprint_target or fingerprint_target.endswith((":all", ":*")):
+            fail("target %s is a pattern; pass fingerprint_target with one concrete label it builds, so a rules change still invalidates %s" % (target, name))
+        fixture_actions(
+            name = "%s_fixture_actions" % name,
+            target = fingerprint_target,
+            extra_toolchains = extra_toolchains,
+            testonly = True,
+        )
+        data.append(":%s_fixture_actions" % name)
 
     # `no-sandbox` rather than `local`: both run the nested `bazel` outside the
     # sandbox, which is all it needs, but a `local` result is also kept out of
@@ -245,6 +254,7 @@ def expect_build_failure_test(
         size = "large",
         tags = ["no-sandbox", "requires-network"],
         fingerprint_target = None,
+        no_fingerprint_reason = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel build` of `target` fails.
 
@@ -273,6 +283,9 @@ def expect_build_failure_test(
             sandbox.
         fingerprint_target: label whose actions key this test, when `target` is a
             pattern rather than one label. Defaults to `target`.
+        no_fingerprint_reason: why no action fingerprint can key this test. Setting
+            it tags the test `external`, so it re-runs every time instead of being
+            served a result that cannot notice a change in the rules.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -288,6 +301,7 @@ def expect_build_failure_test(
         size = size,
         tags = tags,
         fingerprint_target = fingerprint_target,
+        no_fingerprint_reason = no_fingerprint_reason,
         **kwargs
     )
 
@@ -301,6 +315,7 @@ def expect_build_success_test(
         size = "large",
         tags = ["no-sandbox", "requires-network"],
         fingerprint_target = None,
+        no_fingerprint_reason = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel build` of `target` succeeds.
 
@@ -332,6 +347,9 @@ def expect_build_success_test(
         tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
         fingerprint_target: label whose actions key this test, when `target` is a
             pattern rather than one label. Defaults to `target`.
+        no_fingerprint_reason: why no action fingerprint can key this test. Setting
+            it tags the test `external`, so it re-runs every time instead of being
+            served a result that cannot notice a change in the rules.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -347,6 +365,7 @@ def expect_build_success_test(
         size = size,
         tags = tags,
         fingerprint_target = fingerprint_target,
+        no_fingerprint_reason = no_fingerprint_reason,
         **kwargs
     )
 
@@ -361,6 +380,7 @@ def expect_test_failure_test(
         size = "large",
         tags = ["no-sandbox", "requires-network"],
         fingerprint_target = None,
+        no_fingerprint_reason = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel test`/`bazel coverage` of `target` fails.
 
@@ -386,6 +406,9 @@ def expect_test_failure_test(
         tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
         fingerprint_target: label whose actions key this test, when `target` is a
             pattern rather than one label. Defaults to `target`.
+        no_fingerprint_reason: why no action fingerprint can key this test. Setting
+            it tags the test `external`, so it re-runs every time instead of being
+            served a result that cannot notice a change in the rules.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -401,6 +424,7 @@ def expect_test_failure_test(
         size = size,
         tags = tags,
         fingerprint_target = fingerprint_target,
+        no_fingerprint_reason = no_fingerprint_reason,
         **kwargs
     )
 
@@ -417,6 +441,7 @@ def expect_test_success_test(
         size = "large",
         tags = ["no-sandbox", "requires-network"],
         fingerprint_target = None,
+        no_fingerprint_reason = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel test`/`bazel coverage` of `target` succeeds.
 
@@ -453,6 +478,9 @@ def expect_test_success_test(
         tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
         fingerprint_target: label whose actions key this test, when `target` is a
             pattern rather than one label. Defaults to `target`.
+        no_fingerprint_reason: why no action fingerprint can key this test. Setting
+            it tags the test `external`, so it re-runs every time instead of being
+            served a result that cannot notice a change in the rules.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -469,5 +497,6 @@ def expect_test_success_test(
         size = size,
         tags = tags,
         fingerprint_target = fingerprint_target,
+        no_fingerprint_reason = no_fingerprint_reason,
         **kwargs
     )

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -29,7 +29,9 @@ the outer Bazel handed this test. So the files that decide whether the test
 passes are not inputs of the test, and Bazel would serve a stale pass. These
 tests therefore name those files by hand:
 
-- the fixture's own package (globbed below);
+- the fixture's own package (globbed below); a fixture in another package is
+  tagged `external`, because a macro cannot verify that caller `data` covers
+  every source the nested target reads;
 - the toolchains a `--extra_toolchains` flag registers, by analysing the
   fixture under them (see collect_actions.bzl);
 - the repo `.bazelrc`, which CI steps append to, so two steps that differ only
@@ -107,7 +109,8 @@ def _nested_bazel_test(
         no_fingerprint_reason,
         bazel_arg_files = [],
         **kwargs):
-    args = ["--command", command, "--target", _absolutize(target)]
+    absolute_target = _absolutize(target)
+    args = ["--command", command, "--target", absolute_target]
     if expect_success:
         args += ["--expect-success"]
 
@@ -154,8 +157,7 @@ def _nested_bazel_test(
     # source file in this package and declare it as runfiles: editing any of them
     # changes the test's cache key and forces a re-run. This covers the common
     # case of a fixture whose sources live alongside its BUILD file; a `target` in
-    # another package is not tracked (pass its sources via `data` if you need
-    # that).
+    # another package is tagged `external` below.
     code_under_test = native.glob(["**/*"], allow_empty = True)
 
     # Both entries must be in the test's runfiles (a file reaches runfiles only if
@@ -192,7 +194,13 @@ def _nested_bazel_test(
     # toolchain deps compiles nothing at all. Such a test states why and is
     # tagged `external`, which keeps it out of the cache entirely -- a test
     # without a fingerprint must not be served a stale pass.
-    if no_fingerprint_reason:
+    current_package = "//%s:" % native.package_name()
+    cross_package_fixture = not absolute_target.startswith(current_package)
+    if no_fingerprint_reason or cross_package_fixture:
+        # The package glob above cannot cross a Bazel package boundary, and a
+        # macro cannot prove that caller `data` covers every source of a target
+        # or pattern. Keep cross-package results out of the cache rather than
+        # serve a stale pass after an undeclared source edit.
         tags = tags + ["external"]
     else:
         # `target` may be a pattern, which has no single configured target to read
@@ -282,7 +290,9 @@ def expect_build_failure_test(
             nested `bazel build` fetches external repos and must run outside the
             sandbox.
         fingerprint_target: label whose actions key this test, when `target` is a
-            pattern rather than one label. Defaults to `target`.
+            pattern rather than one label. Defaults to `target`. Ignored when
+            `target` is in another package: such a fixture is always tagged
+            `external` instead (see the module docstring).
         no_fingerprint_reason: why no action fingerprint can key this test. Setting
             it tags the test `external`, so it re-runs every time instead of being
             served a result that cannot notice a change in the rules.
@@ -346,7 +356,9 @@ def expect_build_success_test(
         size: test size; defaults to `"large"`.
         tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
         fingerprint_target: label whose actions key this test, when `target` is a
-            pattern rather than one label. Defaults to `target`.
+            pattern rather than one label. Defaults to `target`. Ignored when
+            `target` is in another package: such a fixture is always tagged
+            `external` instead (see the module docstring).
         no_fingerprint_reason: why no action fingerprint can key this test. Setting
             it tags the test `external`, so it re-runs every time instead of being
             served a result that cannot notice a change in the rules.
@@ -405,7 +417,9 @@ def expect_test_failure_test(
         size: test size; defaults to `"large"`.
         tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
         fingerprint_target: label whose actions key this test, when `target` is a
-            pattern rather than one label. Defaults to `target`.
+            pattern rather than one label. Defaults to `target`. Ignored when
+            `target` is in another package: such a fixture is always tagged
+            `external` instead (see the module docstring).
         no_fingerprint_reason: why no action fingerprint can key this test. Setting
             it tags the test `external`, so it re-runs every time instead of being
             served a result that cannot notice a change in the rules.
@@ -477,7 +491,9 @@ def expect_test_success_test(
         size: test size; defaults to `"large"`.
         tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
         fingerprint_target: label whose actions key this test, when `target` is a
-            pattern rather than one label. Defaults to `target`.
+            pattern rather than one label. Defaults to `target`. Ignored when
+            `target` is in another package: such a fixture is always tagged
+            `external` instead (see the module docstring).
         no_fingerprint_reason: why no action fingerprint can key this test. Setting
             it tags the test `external`, so it re-runs every time instead of being
             served a result that cannot notice a change in the rules.

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -21,14 +21,64 @@ A label inside a `build_args`/`bazel_args` flag value (e.g.
 `target`, it is not absolutized against the caller's package, because the
 nested `bazel` runs from the workspace root. Always write such a label out in
 full, even for a toolchain defined in the same package as the caller.
+
+Cacheability
+------------
+The nested `bazel` builds from the git checkout on disk, not from the runfiles
+the outer Bazel handed this test. So the files that decide whether the test
+passes are not inputs of the test, and Bazel would serve a stale pass. These
+tests therefore name those files by hand:
+
+- the fixture's own package (globbed below);
+- the toolchains a `--extra_toolchains` flag registers, by analysing the
+  fixture under them (see collect_actions.bzl);
+- the repo `.bazelrc`, which CI steps append to, so two steps that differ only
+  by those lines no longer share one result;
+- `MODULE.bazel` and its lock, which fix the dependency versions;
+- `.bazelversion`, which picks the Bazel binary the nested build runs;
+- the jars of the compiler and of the test runners, because the fixture's
+  command line carries their paths and not their content;
+- a fingerprint of the actions the fixture and its dependencies run (see
+  collect_actions.bzl). This is what makes an edit to the rules re-run the test.
+
+Editing `.bazelversion` re-runs the tests. What that file cannot catch is a CI
+step which leaves it alone and points bazelisk at another binary. One step does
+that (`last_green`), and it keeps its own cache key regardless, because it
+appends three flags to `.bazelrc`, which is on the list above.
+
+Outside the list is whatever the network serves while external repositories are
+fetched. `MODULE.bazel.lock` pins the versions, so what is exposed is a flaky
+download rather than a silent change in what is being tested. Catching an input
+nobody thought of would take a run with `--nocache_test_results` on the branch
+we merge into, which means a step in `.bazelci/presubmit.yml`; this change does
+not touch CI configuration.
+
+A fixture that fails during analysis never runs an action, so there is nothing
+to fingerprint and no honest cache key for it. Assert on such a target with
+expect_analysis_failure_test, which asks Bazel directly.
 """
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//test/expect_build_failure:collect_actions.bzl", "fixture_actions")
 
 _HELPER = "//test/expect_build_failure:expect_build_failure.sh"
 
 # Sourced at runtime by _HELPER, so it must be present in the test's runfiles.
 _NESTED_BAZEL_LIB = "//test/expect_build_failure:nested_bazel.sh"
+
+# The nested `bazel` runs the compiler this repo builds, so a change in its Java
+# sources changes what the test exercises. The command line only carries the
+# jar's path, so the jar itself has to be an input for its content to count.
+_SCALAC_JAR = "//src/java/io/bazel/rulesscala/scalac:scalac_deploy.jar"
+
+# The compiler jar above does not pull in the test runners, and a nested
+# `bazel test` runs through them, so their content decides its outcome too.
+_RUNNER_JARS = [
+    "//src/java/io/bazel/rulesscala/test_discovery:test_discovery.jar",
+    "//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery.jar",
+    "//src/java/io/bazel/rulesscala/scala_test:librunner.jar",
+    "//src/java/io/bazel/rulesscala/coverage/instrumenter:instrumenter.jar",
+]
 
 def _absolutize(target):
     # The nested `bazel <command>` runs from the workspace root, so a
@@ -53,6 +103,7 @@ def _nested_bazel_test(
         reject,
         size,
         tags,
+        fingerprint_target,
         bazel_arg_files = [],
         **kwargs):
     args = ["--command", command, "--target", _absolutize(target)]
@@ -115,10 +166,44 @@ def _nested_bazel_test(
     #     directory the nested `bazel <command>` must run in. See
     #     _nested_bazel_find_workspace in nested_bazel.sh.
     #   - nested_bazel.sh: sourced at runtime by the helper script.
+    # Everything the nested `bazel` reads and this test's own key would
+    # otherwise miss: the repo `.bazelrc` (CI steps append to it, so two steps
+    # would otherwise share one cached result), the resolved dependency
+    # versions, the Bazel version bazelisk picks, and the compiler jar.
     data = [
         "//:MODULE.bazel",
+        "//:MODULE.bazel.lock",
+        "//:.bazelrc",
+        "//:.bazelversion",
+        _SCALAC_JAR,
         _NESTED_BAZEL_LIB,
-    ] + expect + reject + bazel_arg_files + code_under_test + kwargs.pop("data", [])
+    ] + _RUNNER_JARS + expect + reject + bazel_arg_files + code_under_test + kwargs.pop("data", [])
+    # The fingerprint below is taken under these, so that a change in a toolchain
+    # the nested build registers re-runs the test.
+    extra_toolchains = [
+        arg[len("--extra_toolchains="):]
+        for arg in bazel_args
+        if arg.startswith("--extra_toolchains=")
+    ]
+
+    # `target` may be a pattern, which has no single configured target to read
+    # actions from. Rather than leave such a test without a key, ask for one
+    # concrete target the pattern builds.
+    fingerprint_target = fingerprint_target or target
+    if "..." in fingerprint_target or fingerprint_target.endswith((":all", ":*")):
+        fail("target %s is a pattern; pass fingerprint_target with one concrete label it builds, so a rules change still invalidates %s" % (target, name))
+    fixture_actions(
+        name = "%s_fixture_actions" % name,
+        target = fingerprint_target,
+        extra_toolchains = extra_toolchains,
+        testonly = True,
+    )
+    data.append(":%s_fixture_actions" % name)
+
+    # `no-sandbox` rather than `local`: both run the nested `bazel` outside the
+    # sandbox, which is all it needs, but a `local` result is also kept out of
+    # the shared cache. `no-remote-exec` because it reads this machine's tree.
+    execution_tags = tags + ["exclusive", "no-remote-exec"]
 
     # De-duplicate by canonical label: `code_under_test` re-lists files that are
     # also named explicitly (e.g. the expect/reject `.txt`s, passed as `:foo.txt`),
@@ -143,10 +228,10 @@ def _nested_bazel_test(
         srcs = [_HELPER],
         args = args,
         data = deduped_data,
-        # Each of these runs a nested `bazel` that takes the shared nested output
-        # base's lock. Run them one at a time (`exclusive`) so they do not queue
-        # behind each other and blow the test timeout.
-        tags = tags + ["exclusive"],
+        # `exclusive`: each runs a nested `bazel` that takes the shared output
+        # base's lock, so running them one at a time keeps them off each other's
+        # timeout.
+        tags = execution_tags,
         **kwargs
     )
 
@@ -158,7 +243,8 @@ def expect_build_failure_test(
         expect = [],
         reject = [],
         size = "large",
-        tags = ["local", "requires-network"],
+        tags = ["no-sandbox", "requires-network"],
+        fingerprint_target = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel build` of `target` fails.
 
@@ -182,9 +268,11 @@ def expect_build_failure_test(
             the build output. Automatically added to the test's `data`.
         size: test size; defaults to `"large"` (the nested Bazel invocation is
             slow and, on a cold cache, serializes on the shared output base).
-        tags: test tags; defaults to `["local", "requires-network"]` because the
+        tags: test tags; defaults to `["no-sandbox", "requires-network"]` because the
             nested `bazel build` fetches external repos and must run outside the
             sandbox.
+        fingerprint_target: label whose actions key this test, when `target` is a
+            pattern rather than one label. Defaults to `target`.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -199,6 +287,7 @@ def expect_build_failure_test(
         reject = reject,
         size = size,
         tags = tags,
+        fingerprint_target = fingerprint_target,
         **kwargs
     )
 
@@ -210,7 +299,8 @@ def expect_build_success_test(
         expect = [],
         reject = [],
         size = "large",
-        tags = ["local", "requires-network"],
+        tags = ["no-sandbox", "requires-network"],
+        fingerprint_target = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel build` of `target` succeeds.
 
@@ -239,7 +329,9 @@ def expect_build_success_test(
         reject: file labels whose (newline-stripped) contents must NOT appear in
             the build output. Automatically added to the test's `data`.
         size: test size; defaults to `"large"`.
-        tags: test tags; defaults to `["local", "requires-network"]`.
+        tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
+        fingerprint_target: label whose actions key this test, when `target` is a
+            pattern rather than one label. Defaults to `target`.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -254,6 +346,7 @@ def expect_build_success_test(
         reject = reject,
         size = size,
         tags = tags,
+        fingerprint_target = fingerprint_target,
         **kwargs
     )
 
@@ -266,7 +359,8 @@ def expect_test_failure_test(
         expect = [],
         reject = [],
         size = "large",
-        tags = ["local", "requires-network"],
+        tags = ["no-sandbox", "requires-network"],
+        fingerprint_target = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel test`/`bazel coverage` of `target` fails.
 
@@ -289,7 +383,9 @@ def expect_test_failure_test(
         reject: file labels whose (newline-stripped) contents must NOT appear in
             the output. Automatically added to the test's `data`.
         size: test size; defaults to `"large"`.
-        tags: test tags; defaults to `["local", "requires-network"]`.
+        tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
+        fingerprint_target: label whose actions key this test, when `target` is a
+            pattern rather than one label. Defaults to `target`.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -304,6 +400,7 @@ def expect_test_failure_test(
         reject = reject,
         size = size,
         tags = tags,
+        fingerprint_target = fingerprint_target,
         **kwargs
     )
 
@@ -318,7 +415,8 @@ def expect_test_success_test(
         expect = [],
         reject = [],
         size = "large",
-        tags = ["local", "requires-network"],
+        tags = ["no-sandbox", "requires-network"],
+        fingerprint_target = None,
         **kwargs):
     """Declares an `sh_test` asserting that `bazel test`/`bazel coverage` of `target` succeeds.
 
@@ -352,7 +450,9 @@ def expect_test_success_test(
         reject: file labels whose (newline-stripped) contents must NOT appear in
             the output. Automatically added to the test's `data`.
         size: test size; defaults to `"large"`.
-        tags: test tags; defaults to `["local", "requires-network"]`.
+        tags: test tags; defaults to `["no-sandbox", "requires-network"]`.
+        fingerprint_target: label whose actions key this test, when `target` is a
+            pattern rather than one label. Defaults to `target`.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
     _nested_bazel_test(
@@ -368,5 +468,6 @@ def expect_test_success_test(
         reject = reject,
         size = size,
         tags = tags,
+        fingerprint_target = fingerprint_target,
         **kwargs
     )

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -30,8 +30,10 @@ passes are not inputs of the test, and Bazel would serve a stale pass. These
 tests therefore name those files by hand:
 
 - the fixture's own package (globbed below); a fixture in another package is
-  tagged `external`, because a macro cannot verify that caller `data` covers
-  every source the nested target reads;
+  tagged `external` only if `target` is a pattern, because a macro cannot
+  verify that caller `data` covers every source of a pattern -- a concrete
+  cross-package label gets fingerprinted below instead, and needs
+  `target`'s visibility to reach the caller's package;
 - the toolchains a `--extra_toolchains` flag registers, by analysing the
   fixture under them (see collect_actions.bzl);
 - the repo `.bazelrc`, which CI steps append to, so two steps that differ only

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -196,19 +196,37 @@ def _nested_bazel_test(
     # without a fingerprint must not be served a stale pass.
     current_package = "//%s:" % native.package_name()
     cross_package_fixture = not absolute_target.startswith(current_package)
-    if no_fingerprint_reason or cross_package_fixture:
+
+    # `target` may be a pattern (a wildcard like `//pkg/...`), which has no
+    # single configured target to read actions from and no single label a
+    # cross-package caller could declare as `data`. A concrete label doesn't
+    # have that problem either way, so only a cross-package *pattern* is
+    # unfixable without the caller's help.
+    fingerprint_target = fingerprint_target or target
+    fingerprint_target_is_pattern = "..." in fingerprint_target or fingerprint_target.endswith((":all", ":*"))
+
+    if no_fingerprint_reason or (cross_package_fixture and fingerprint_target_is_pattern):
         # The package glob above cannot cross a Bazel package boundary, and a
-        # macro cannot prove that caller `data` covers every source of a target
-        # or pattern. Keep cross-package results out of the cache rather than
-        # serve a stale pass after an undeclared source edit.
+        # macro cannot prove that caller `data` covers every source of a
+        # pattern -- there's no single label to declare. Keep such results out
+        # of the cache rather than serve a stale pass after an undeclared
+        # source edit.
         tags = tags + ["external"]
     else:
-        # `target` may be a pattern, which has no single configured target to read
-        # actions from. Rather than leave such a test without a key, ask for one
-        # concrete target the pattern builds.
-        fingerprint_target = fingerprint_target or target
-        if "..." in fingerprint_target or fingerprint_target.endswith((":all", ":*")):
+        if fingerprint_target_is_pattern:
             fail("target %s is a pattern; pass fingerprint_target with one concrete label it builds, so a rules change still invalidates %s" % (target, name))
+        # A cross-package fixture still gets this real, non-empty action
+        # fingerprint, which does catch a rules change. What it does not
+        # catch: a plain source edit to the fixture that doesn't change any
+        # command line, because the package glob above only reaches this
+        # package. Closing that gap would mean depending on the fixture's own
+        # build output, but nothing here can tell whether that output builds
+        # under the *outer* build's plain configuration -- these fixtures are
+        # routinely written to fail, or to only succeed under a toolchain
+        # override the nested `bazel` supplies, and a `tags = ["manual"]` on
+        # such a target lives in a BUILD file this macro cannot read. So this
+        # is the same tradeoff a near-empty fingerprint already accepts
+        # elsewhere in this file.
         fixture_actions(
             name = "%s_fixture_actions" % name,
             target = fingerprint_target,

--- a/test/expect_build_failure/nested_bazel.sh
+++ b/test/expect_build_failure/nested_bazel.sh
@@ -91,6 +91,15 @@ _nested_bazel_common_opts=()
 # then serialize on Bazel's output-base lock (each inner `bazel --batch` waits for
 # the lock rather than failing), which keeps the extracted external repos warm and
 # avoids multiplying ~1GB of Scala jars across a separate output base per test.
+_nested_bazel_home_hint() {
+  if [[ -n "${RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME:-}" ]]; then
+    return
+  fi
+  echo "note: the nested \`bazel\` ran with a scrubbed HOME, so your ~/.bazelrc was" >&2
+  echo "      ignored. If it carries settings the build needs (a download proxy, for" >&2
+  echo "      instance), re-run with RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1." >&2
+}
+
 nested_bazel_setup() {
   local output_base_name="${1:?nested_bazel_setup requires an output-base directory name}"
 
@@ -107,7 +116,17 @@ nested_bazel_setup() {
   # a corporate proxy via `--experimental_downloader_config`). Resolve the real
   # home from the passwd database and run with it so it behaves like the user's
   # own `bazel build`. On hosts without such an rc (e.g. CI) this is a no-op.
-  _nested_bazel_real_home="$(eval echo "~$(id -un)" 2>/dev/null || true)"
+  # Any failure below may be the missing rc rather than the code under test, and
+  # the reader has no way to guess that, so say it on every failing exit.
+  trap '_nested_bazel_status=$?; if [[ "${_nested_bazel_status}" -ne 0 ]]; then _nested_bazel_home_hint; fi' EXIT
+
+  # Opt-in: the user's rc is not a declared input of the test, so reading it by
+  # default would let a cached result depend on a file outside the repo. CI stays
+  # hermetic; a developer who needs the rc sets the variable.
+  _nested_bazel_real_home=""
+  if [[ -n "${RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME:-}" ]]; then
+    _nested_bazel_real_home="$(eval echo "~$(id -un)" 2>/dev/null || true)"
+  fi
 
   _nested_bazel_common_opts=()
   # Derive the parent's repository (download) cache from its output base rather

--- a/test/expect_build_failure/nested_bazel.sh
+++ b/test/expect_build_failure/nested_bazel.sh
@@ -97,7 +97,8 @@ _nested_bazel_home_hint() {
   fi
   echo "note: the nested \`bazel\` ran with a scrubbed HOME, so your ~/.bazelrc was" >&2
   echo "      ignored. If it carries settings the build needs (a download proxy, for" >&2
-  echo "      instance), re-run with RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1." >&2
+  echo "      instance), re-run bazel test with --nocache_test_results and" >&2
+  echo "      --test_env=RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1." >&2
 }
 
 nested_bazel_setup() {

--- a/test/proto/custom_generator/BUILD.bazel
+++ b/test/proto/custom_generator/BUILD.bazel
@@ -21,6 +21,7 @@ expect_test_success_test(
 
 scala_proto_library(
     name = "any_proto_scala",
+    visibility = ["//test:__subpackages__"],
     deps = ["@com_google_protobuf//:any_proto"],
 )
 

--- a/test/proto_source_root/BUILD
+++ b/test/proto_source_root/BUILD
@@ -4,5 +4,6 @@ package(default_testonly = 1)
 
 expect_build_success_test(
     name = "proto_source_root",
+    no_fingerprint_reason = "scala_proto compiles through an aspect of its own, whose actions collect_actions.bzl cannot read",
     target = "//test/proto_source_root/user:user_scala",
 )

--- a/test/scala_library_suite/BUILD
+++ b/test/scala_library_suite/BUILD
@@ -1,3 +1,4 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//scala:scala.bzl", "scala_library_suite")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
@@ -35,4 +36,19 @@ scala_library_suite(
 expect_build_failure_test(
     name = "scala_library_suite_invalid_source_build_test",
     target = ":library_suite_with_invalid_source",
+)
+
+# The fingerprint that keys the test above has to reach the actions of the
+# fixture's *dependencies*: a suite compiles in its children and only merges
+# their jars, so a fingerprint of the suite target alone carries no Scalac
+# command line and a rules change would not invalidate anything.
+sh_test(
+    name = "fingerprint_reaches_dependency_actions",
+    srcs = ["//test/sh_tests:string_in_file.sh"],
+    args = [
+        "true",
+        "Scalac",
+        "$(rootpath :scala_library_suite_dep_on_children_build_test_fixture_actions)",
+    ],
+    data = [":scala_library_suite_dep_on_children_build_test_fixture_actions"],
 )

--- a/test/scala_library_suite/BUILD
+++ b/test/scala_library_suite/BUILD
@@ -44,7 +44,7 @@ expect_build_failure_test(
 # command line and a rules change would not invalidate anything.
 sh_test(
     name = "fingerprint_reaches_dependency_actions",
-    srcs = ["//test/sh_tests:string_in_file.sh"],
+    srcs = ["//test/string_checks:string_in_file.sh"],
     args = [
         "true",
         "Scalac",

--- a/test/scala_proto_failing_generator/BUILD
+++ b/test/scala_proto_failing_generator/BUILD
@@ -11,5 +11,6 @@ expect_build_failure_test(
         "--extra_toolchains=//test/proto/custom_generator:failing_scala_proto_toolchain",
     ],
     expect = ["expected_generator_failure.txt"],
+    no_fingerprint_reason = "scala_proto compiles through an aspect of its own, whose actions collect_actions.bzl cannot read",
     target = "//test/proto/custom_generator:any_proto_scala",
 )

--- a/test/scala_test/BUILD
+++ b/test/scala_test/BUILD
@@ -11,6 +11,7 @@ scala_test(
 # @rules_shell -- see //test/jmh's precedent.
 scala_test(
     name = "b",
+    visibility = ["//test:__subpackages__"],
     srcs = ["B.scala"],
     deps = [":a"],
 )

--- a/test/semanticdb/BUILD
+++ b/test/semanticdb/BUILD
@@ -97,6 +97,7 @@ _TOOLCHAIN_DEPS_SCALA_VERSIONS = [
         # cover it. Depend on the built target directly so a change to its .bzl
         # sources still invalidates this test's cache key.
         data = ["//scala/private/toolchain_deps:semanticdb"],
+        no_fingerprint_reason = "this nested build only builds toolchain deps, so it runs no rules_scala action to fingerprint; the data above covers what it does build",
         target = "//scala/private/toolchain_deps:semanticdb",
     )
     for scala_version in _TOOLCHAIN_DEPS_SCALA_VERSIONS

--- a/test/src/main/scala/scalarules/test/classpath_resources/BUILD
+++ b/test/src/main/scala/scalarules/test/classpath_resources/BUILD
@@ -21,4 +21,5 @@ scala_binary(
         "//test/src/main/resources/scalarules/test/classpath_resource2:classpath-resource",
     ],
     main_class = "scalarules.test.classpathresources.ObjectWithDuplicateClasspathResources",
+    visibility = ["//test:__subpackages__"],
 )

--- a/test/strict_dependency/BUILD
+++ b/test/strict_dependency/BUILD
@@ -7,6 +7,7 @@ load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failu
 expect_build_success_test(
     name = "plus_one_deps_only_works_for_java_info_targets_test",
     build_args = ["--extra_toolchains=//test_expect_failure/plus_one_deps:plus_one_deps"],
+    no_fingerprint_reason = "test_proto is a plain proto_library, so it runs no rules_scala action to fingerprint",
     target = "//test/proto:test_proto",
 )
 
@@ -41,5 +42,6 @@ expect_build_failure_test(
     name = "external_deps_stamped_label_test",
     build_args = ["--extra_toolchains=//test/toolchains:ast_plus_one_deps_unused_deps_error"],
     expect = ["expected_external_deps_stamped_label.txt"],
+    no_fingerprint_reason = "java_lib_with_a_transitive_external_dep is a plain java_library, so it runs no rules_scala action to fingerprint",
     target = "//test/missing_direct_deps/external_deps:java_lib_with_a_transitive_external_dep",
 )

--- a/test/strict_dependency/scala_proto_deps/BUILD
+++ b/test/strict_dependency/scala_proto_deps/BUILD
@@ -85,6 +85,7 @@ expect_build_failure_test(
     name = "stamp_by_convention_test",
     build_args = ["--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error,//test/strict_dependency/scala_proto_deps:stamp_by_convention_toolchain"],
     expect = ["expected_stamp_by_convention.txt"],
+    no_fingerprint_reason = "under this toolchain combination collides with custom_phase_stamping_test below on :some_proto's aspect application (see that test's own no_fingerprint_reason)",
     target = ":uses_transitive_scala_proto",
 )
 
@@ -92,5 +93,6 @@ expect_build_failure_test(
     name = "custom_phase_stamping_test",
     build_args = ["--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error,//test/strict_dependency/scala_proto_deps:stamp_by_convention_toolchain"],
     expect = ["expected_custom_phase_stamping.txt"],
+    no_fingerprint_reason = "fingerprinting this target under the same --extra_toolchains as stamp_by_convention_test above analyses :some_proto under two different aspect stacks (scala_proto_aspect alone vs. scala_proto_aspect + this package's custom_stamping_apsect) in the same configuration, which Bazel reports as an ActionConflictException on :some_proto's generated jar",
     target = ":uses_transitive_some_proto_custom_suffix",
 )

--- a/test/strict_dependency/scala_proto_deps/BUILD
+++ b/test/strict_dependency/scala_proto_deps/BUILD
@@ -93,6 +93,6 @@ expect_build_failure_test(
     name = "custom_phase_stamping_test",
     build_args = ["--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error,//test/strict_dependency/scala_proto_deps:stamp_by_convention_toolchain"],
     expect = ["expected_custom_phase_stamping.txt"],
-    no_fingerprint_reason = "fingerprinting this target under the same --extra_toolchains as stamp_by_convention_test above analyses :some_proto under two different aspect stacks (scala_proto_aspect alone vs. scala_proto_aspect + this package's custom_stamping_apsect) in the same configuration, which Bazel reports as an ActionConflictException on :some_proto's generated jar",
+    no_fingerprint_reason = "fingerprinting this target under the same --extra_toolchains as stamp_by_convention_test above analyses :some_proto under two different aspect stacks (scala_proto_aspect alone vs. scala_proto_aspect + this package's custom_stamping_aspect) in the same configuration, which Bazel reports as an ActionConflictException on :some_proto's generated jar",
     target = ":uses_transitive_some_proto_custom_suffix",
 )

--- a/test/strict_dependency/scala_proto_deps/customized_scala_proto.bzl
+++ b/test/strict_dependency/scala_proto_deps/customized_scala_proto.bzl
@@ -29,6 +29,6 @@ _custom_phases = {
     ],
 }
 
-custom_stamping_apsect = make_scala_proto_aspect(_custom_phases)
+custom_stamping_aspect = make_scala_proto_aspect(_custom_phases)
 
-custom_stamping_scala_proto_library = make_scala_proto_library(aspects = [custom_stamping_apsect])
+custom_stamping_scala_proto_library = make_scala_proto_library(aspects = [custom_stamping_aspect])

--- a/test/string_checks/BUILD
+++ b/test/string_checks/BUILD
@@ -10,6 +10,7 @@ exports_files(
     visibility = [
         "//test/phase/adjustment:__pkg__",
         "//test/phase/add_to_all_rules:__pkg__",
+        "//test/scala_library_suite:__pkg__",
         "//test/src/main/scala/scalarules/test/resources:__pkg__",
         "//test/src/main/scala/scalarules/test/twitter_scrooge/strings:__pkg__",
     ],

--- a/test/toolchains/scalac_jvm_opts/BUILD
+++ b/test/toolchains/scalac_jvm_opts/BUILD
@@ -96,5 +96,6 @@ expect_build_success_test(
 expect_build_success_test(
     name = "scalac_jvm_flags_with_scalapb_build_test",
     build_args = [_PASSING],
+    no_fingerprint_reason = "scala_proto compiles through an aspect of its own, whose actions collect_actions.bzl cannot read",
     target = ":proto",
 )

--- a/test/twitter_scrooge_jdk11/BUILD
+++ b/test/twitter_scrooge_jdk11/BUILD
@@ -16,15 +16,6 @@ expect_build_success_test(
         "--java_runtime_version=remotejdk_11",
         "--tool_java_runtime_version=remotejdk_11",
     ],
-    # The built target's sources live in another package, so the macro's
-    # automatic glob of this package doesn't cover them for staleness. Depend
-    # on a public target that transitively covers most of that package's
-    # scrooge sources (:twitter_scrooge_tests itself is package-private) so a
-    # source change still invalidates this test's cache key.
-    data = ["//test/src/main/scala/scalarules/test/twitter_scrooge:justscrooges_scala_and_java"],
-    # The target below is a pattern, so name one concrete label it builds for the
-    # action fingerprint that keys this test.
-    fingerprint_target = "//test/src/main/scala/scalarules/test/twitter_scrooge:justscrooges_scala_and_java",
     # Absolute wildcard, not package-relative: _absolutize passes a "//"-prefixed
     # label through unchanged, so this reaches the nested `bazel build` as-is.
     target = "//test/src/main/scala/scalarules/test/twitter_scrooge/...",

--- a/test/twitter_scrooge_jdk11/BUILD
+++ b/test/twitter_scrooge_jdk11/BUILD
@@ -22,6 +22,9 @@ expect_build_success_test(
     # scrooge sources (:twitter_scrooge_tests itself is package-private) so a
     # source change still invalidates this test's cache key.
     data = ["//test/src/main/scala/scalarules/test/twitter_scrooge:justscrooges_scala_and_java"],
+    # The target below is a pattern, so name one concrete label it builds for the
+    # action fingerprint that keys this test.
+    fingerprint_target = "//test/src/main/scala/scalarules/test/twitter_scrooge:justscrooges_scala_and_java",
     # Absolute wildcard, not package-relative: _absolutize passes a "//"-prefixed
     # label through unchanged, so this reaches the nested `bazel build` as-is.
     target = "//test/src/main/scala/scalarules/test/twitter_scrooge/...",


### PR DESCRIPTION
### Description

The nested `expect_*` tests run a `bazel` of their own against the real source tree, invisible to the outer Bazel. Two problems follow: a cached pass can survive the change it was meant to catch, and `local` keeps every one of the 61 tests out of the shared cache, so every build re-runs all of them.

Each test now declares what decides its outcome: a fingerprint of the actions its fixture and its dependencies run (an aspect in `collect_actions.bzl`), the toolchains a `--extra_toolchains` flag registers (a transition), and the repo `.bazelrc`, `MODULE.bazel`(`.lock`), `.bazelversion`, and the compiler/runner jars. `local` becomes `no-sandbox` + `no-remote-exec`.

Analysis fails if the fingerprint carries no rules_scala action -- a fingerprint that can't notice a rules change must not serve a stale pass. 11 tests hit this (`scala_proto`/`semanticdb` compiling through their own aspect, two plain `proto_library`/`java_library` targets, and two `test/strict_dependency/scala_proto_deps` tests whose shared `--extra_toolchains` puts them under the same config as `:some_proto`'s own custom aspect, which Bazel reports as an `ActionConflictException`). Each says why with `no_fingerprint_reason` and is tagged `external`.

A fixture in another package used to be `external` unconditionally, since the macro can't verify a caller's `data` covers every source. Now that's only true when `target` is a pattern with no single label to fingerprint (`test/twitter_scrooge_jdk11`'s `.../...`); a concrete label gets the same real fingerprint a same-package fixture gets. It still can't safely add the fixture's own build output to `data` for full source coverage -- these fixtures are routinely `tags = ["manual"]`, built to fail or to only succeed under a toolchain the nested `bazel` supplies, and this macro can't read that tag from another package's BUILD file. Same tradeoff a near-empty fingerprint already accepts.

Two fixtures that fail during analysis moved to `analysistest` (#1922, merged, this PR's base).

`test/expect_build_failure/README.md` has the rest.

### Motivation

Removes a risk (a regression a nested test can no longer catch) and a cost (every nested test re-running on every build). The cross-package fixtures now cache: running them twice, the second run shows `(cached) PASSED`.

CI, same two steps against pre-branch master (#1918's build #6615) and this branch (#6637):

| | master | this branch |
|---|---|---|
| whole build | 1h19m05s | 1h16m48s |
| `bazel test //...` ubuntu | 2847s | 1484s |
| `bazel test //...` macOS | 3477s | 823s |
| `./test_rules_scala` (5 platform variants) | 3137-4712s | 3661-4600s |

Release impact: tests only.
