### PR TITLE
Pass output paths as File objects so actions are path-mapping safe

### DIFF
--- a/scala/private/phases/phase_merge_jars.bzl
+++ b/scala/private/phases/phase_merge_jars.bzl
@@ -20,7 +20,7 @@ def merge_jars_to_output(ctx, output, jars):
 
     if main_class:
         args.add_all(["--main_class", main_class])
-    args.add_all(["--output", output.path])
+    args.add("--output", output)
 
     args.set_param_file_format("multiline")
     args.use_param_file("@%s")

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -74,9 +74,9 @@ def _write_empty_content(ctx, output_runner):
 
 def _format_args(ctx, src, file):
     args = ctx.actions.args()
-    args.add(ctx.file.config.path)
-    args.add(src.path)
-    args.add(file.path)
+    args.add(ctx.file.config)
+    args.add(src)
+    args.add(file)
     args.set_param_file_format("multiline")
     args.use_param_file("@%s", use_always = True)
     return args

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -99,7 +99,10 @@ def _scala_doc_impl(ctx):
     args.add("-usejavacp")
     args.add("-nowarn")  # turn off warnings for now since they can obscure actual errors for large scala_doc targets
     args.add_all(ctx.attr.scalacopts)
-    args.add("-d", output_path.path)
+    # output_path is a directory, and Args#add rejects those because they may expand to
+    # multiple values. add_all with expand_directories = False passes it as one mapped path.
+    args.add("-d")
+    args.add_all([output_path], expand_directories = False)
     args.add_all(plugins, format_each = "-Xplugin:%s")
     args.add_joined("-classpath", classpath, join_with = ctx.configuration.host_path_separator)
     args.add_all(src_files)


### PR DESCRIPTION
Three actions build their command line with an output path taken as an analysis-time string, which makes them unsafe under `--experimental_output_paths=strip`. Path mapping only rewrites paths that reach the command line as `File` objects through `Args`, so these actions get mapped inputs and an unmapped output, and then write outside the sandbox.

`phase_merge_jars` shows it clearly — line 19 already does the right thing, line 23 does not:

```python
args.add_all(jars, map_each = _fileToPath)      # mapped
args.add_all(["--output", output.path])         # not mapped
```

singlejar then fails:

```
singlejar_local --compression --normalize --sources bazel-out/cfg/bin/foo.jar ...
singlejar_local: output_jar.cc:408:
  bazel-out/k8-fastbuild/bin/foo_deploy.jar: No such file or directory
```

`scala_doc.bzl` and `phase_scalafmt.bzl` have the same shape.

### Verification

Applied as a patch against a repo with ~950 Scala targets and `--modify_execution_info=ScalaDeployJar=+supports-path-mapping`. The target that previously failed with the error above now builds, along with the wider set of `scala_binary` targets I tried (1209 actions). Only the `ScalaDeployJar` path is exercised by that repo — `scala_doc` and `scalafmt` are changed for consistency but I have no targets covering them, so those two are by inspection.

### Not included: ScroogeRule

`twitter_scrooge.bzl` fails under path mapping too, but not for this reason and not fixably this way. It writes the output path and every input path into a worker argfile via `ctx.actions.write`:

```python
worker_content = "{output}\n{paths}\n{flags}".format(output = jar_output.path, paths = path_content, ...)
ctx.actions.write(output = argfile, content = worker_content)
```

Path mapping rewrites command lines, not file contents, so changing `arguments = ["@" + argfile.path]` to use `Args` would not help — the worker still reads unmapped paths out of the file. Making that action mappable means passing paths as arguments rather than as written content, which is a larger change than this PR.
