### PR TITLE
refactor: Migrate missing_direct_deps checks in test_scala_library.sh

### DIFF
--- a/test/missing_direct_deps/BUILD
+++ b/test/missing_direct_deps/BUILD
@@ -1,0 +1,99 @@
+load(
+    "//test/expect_build_failure:expect_build_failure.bzl",
+    "expect_build_failure_test",
+    "expect_build_success_test",
+)
+
+# Fixture lives in test_expect_failure/missing_direct_deps -- shared by this
+# package and by test/shell/test_scala_binary.sh and
+# test/shell/test_strict_dependency.sh (migrating separately), so it stays put
+# instead of being colocated here.
+_INTERNAL_DEPS = "//test_expect_failure/missing_direct_deps/internal_deps"
+_EXTERNAL_DEPS = "//test_expect_failure/missing_direct_deps/external_deps"
+
+_STRICT_DEPS_ERROR = "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
+_STRICT_DEPS_WARN = "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn"
+_DIRECT_DEPS_OFF = "--extra_toolchains=//test/toolchains:high_level_direct_deps"
+
+expect_build_failure_test(
+    name = "fails_on_missing_direct_internal_dep",
+    build_args = [_STRICT_DEPS_ERROR],
+    expect = ["expected_missing_direct_internal_dep.txt"],
+    target = _INTERNAL_DEPS + ":transitive_dependency_user",
+)
+
+expect_build_failure_test(
+    name = "fails_on_missing_direct_external_jar_dep",
+    build_args = [_STRICT_DEPS_ERROR],
+    expect = ["expected_missing_direct_external_jar_dep.txt"],
+    target = _EXTERNAL_DEPS + ":transitive_external_dependency_user",
+)
+
+expect_build_failure_test(
+    name = "fails_on_missing_direct_external_file_group_dep",
+    build_args = [_STRICT_DEPS_ERROR],
+    expect = ["expected_missing_direct_external_file_group_dep.txt"],
+    target = _EXTERNAL_DEPS + ":transitive_external_dependency_user_file_group",
+)
+
+# No --extra_toolchains override: the default toolchain has no strict-deps
+# checking, so a missing direct dep is just an ordinary missing-symbol compile
+# error rather than a buildozer hint.
+expect_build_failure_test(
+    name = "fails_on_missing_direct_dep_by_default",
+    expect = ["expected_not_found_value_c.txt"],
+    target = _INTERNAL_DEPS + ":transitive_dependency_user",
+)
+
+# strict_deps_mode = "warn": the build must still succeed, only the warning
+# text is asserted.
+expect_build_success_test(
+    name = "warns_on_missing_direct_dep_in_warn_mode",
+    build_args = [_STRICT_DEPS_WARN],
+    expect = ["expected_missing_direct_dep_warning.txt"],
+    target = _INTERNAL_DEPS + ":transitive_dependency_user",
+)
+
+expect_build_success_test(
+    name = "warns_on_missing_direct_java_dep_with_strict_java_deps_warn",
+    build_args = ["--strict_java_deps=warn"],
+    expect = ["expected_missing_direct_java_dep.txt"],
+    target = _INTERNAL_DEPS + ":transitive_dependency_java_user",
+)
+
+# --extra_toolchains=high_level_direct_deps explicitly turns strict-deps off
+# (as opposed to fails_on_missing_direct_dep_by_default, which relies on it
+# being off by default) -- same raw compiler error either way.
+expect_build_failure_test(
+    name = "fails_on_missing_direct_dep_in_off_mode",
+    build_args = [_DIRECT_DEPS_OFF],
+    expect = ["expected_not_found_value_c.txt"],
+    target = _INTERNAL_DEPS + ":transitive_dependency_user",
+)
+
+expect_build_failure_test(
+    name = "fails_on_missing_direct_java_dep_with_strict_java_deps_error",
+    build_args = ["--strict_java_deps=error"],
+    expect = ["expected_missing_direct_java_dep.txt"],
+    target = _INTERNAL_DEPS + ":transitive_dependency_java_user",
+)
+
+# dependent_on_some_java_provider's direct dep is a custom_jvm rule wrapping
+# transitive_dependency's ijar -- the buildozer hint must still name the
+# scala_library target, not the ijar/jar file it produced.
+expect_build_failure_test(
+    name = "reports_scala_library_label_not_ijar_on_missing_transitive_dep",
+    build_args = [_STRICT_DEPS_ERROR],
+    expect = ["expected_transitive_dep_label_via_java_provider.txt"],
+    target = _INTERNAL_DEPS + ":dependent_on_some_java_provider",
+)
+
+# Same as above, but the custom_jvm's jar has no stamped manifest to recover a
+# label from, so the message instead names the jar file and the target that
+# produced it.
+expect_build_failure_test(
+    name = "reports_label_from_other_jvm_rule_on_missing_transitive_dep",
+    build_args = [_STRICT_DEPS_ERROR],
+    expect = ["expected_unknown_label_from_unstamped_jar.txt"],
+    target = _INTERNAL_DEPS + ":unstamped_jar_dependent_on_some_java_provider",
+)

--- a/test/missing_direct_deps/expected_missing_direct_dep_warning.txt
+++ b/test/missing_direct_deps/expected_missing_direct_dep_warning.txt
@@ -1,0 +1,1 @@
+warning: Target '//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency' is used but isn't explicitly declared, please add it to the deps.

--- a/test/missing_direct_deps/expected_missing_direct_external_file_group_dep.txt
+++ b/test/missing_direct_deps/expected_missing_direct_external_file_group_dep.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps @com_google_guava_guava_21_0_with_file//:com_google_guava_guava_21_0_with_file' //test_expect_failure/missing_direct_deps/external_deps:transitive_external_dependency_user_file_group

--- a/test/missing_direct_deps/expected_missing_direct_external_jar_dep.txt
+++ b/test/missing_direct_deps/expected_missing_direct_external_jar_dep.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps @com_google_guava_guava_21_0//:com_google_guava_guava_21_0' //test_expect_failure/missing_direct_deps/external_deps:transitive_external_dependency_user

--- a/test/missing_direct_deps/expected_missing_direct_internal_dep.txt
+++ b/test/missing_direct_deps/expected_missing_direct_internal_dep.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency' //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_user

--- a/test/missing_direct_deps/expected_missing_direct_java_dep.txt
+++ b/test/missing_direct_deps/expected_missing_direct_java_dep.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency' //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user

--- a/test/missing_direct_deps/expected_not_found_value_c.txt
+++ b/test/missing_direct_deps/expected_not_found_value_c.txt
@@ -1,0 +1,1 @@
+not found: value C

--- a/test/missing_direct_deps/expected_transitive_dep_label_via_java_provider.txt
+++ b/test/missing_direct_deps/expected_transitive_dep_label_via_java_provider.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency' //test_expect_failure/missing_direct_deps/internal_deps:dependent_on_some_java_provider

--- a/test/missing_direct_deps/expected_unknown_label_from_unstamped_jar.txt
+++ b/test/missing_direct_deps/expected_unknown_label_from_unstamped_jar.txt
@@ -1,0 +1,1 @@
+transitive_dependency_without_manifest.jar which came from @@//test_expect_failure/missing_direct_deps/internal_deps:unstamped_direct_java_provider_dependency

--- a/test/shell/test_scala_library.sh
+++ b/test/shell/test_scala_library.sh
@@ -49,65 +49,6 @@ test_scala_library_expect_no_recompilation_of_target_on_internal_change_of_depen
   test_scala_library_expect_no_recompilation_on_internal_change $1 $2 ":user" "'user'"
 }
 
-test_scala_library_expect_failure_on_missing_direct_internal_deps() {
-  dependenecy_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  test_target='test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_user'
-
-  test_scala_library_expect_failure_on_missing_direct_deps $dependenecy_target $test_target
-}
-
-test_scala_library_expect_failure_on_missing_direct_external_deps_jar() {
-  dependenecy_target='@[a-z_.~+-]*com_google_guava_guava_21_0//:com_google_guava_guava_21_0'
-  test_target='test_expect_failure/missing_direct_deps/external_deps:transitive_external_dependency_user'
-
-  test_scala_library_expect_failure_on_missing_direct_deps $dependenecy_target $test_target
-}
-
-test_scala_library_expect_failure_on_missing_direct_external_deps_file_group() {
-  dependenecy_target='@[a-z_.~+-]*com_google_guava_guava_21_0_with_file//:com_google_guava_guava_21_0_with_file'
-  test_target='test_expect_failure/missing_direct_deps/external_deps:transitive_external_dependency_user_file_group'
-
-  test_scala_library_expect_failure_on_missing_direct_deps $dependenecy_target $test_target
-}
-
-test_scala_library_expect_failure_on_missing_direct_deps_strict_is_disabled_by_default() {
-  expected_message="not found: value C"
-  test_target='test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_user'
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "$expected_message" "$test_target"
-}
-
-test_scala_library_expect_failure_on_missing_direct_deps_warn_mode() {
-  dependenecy_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  test_target='test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_user'
-
-  expected_message="warning: Target '$dependenecy_target' is used but isn't explicitly declared, please add it to the deps"
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn" "ne"
-}
-
-test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java() {
-  dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
-
-  local expected_message="$dependency_target.*$test_target"
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--strict_java_deps=warn" "ne"
-}
-
-test_scala_library_expect_failure_on_missing_direct_deps_off_mode() {
-  #scalac outputs backslashes on windows (triple slash needed for the grep)
-  if is_windows; then
-    local expected_message="test_expect_failure\\\missing_direct_deps\\\internal_deps\\\A.scala:[0-9+]: error: not found: value C"
-  
-  else
-    local expected_message="test_expect_failure/missing_direct_deps/internal_deps/A.scala:[0-9+]: error: not found: value C"
-  fi
-  local test_target='test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_user'
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--extra_toolchains=//test/toolchains:high_level_direct_deps"
-}
-
 test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_dependency() {
   set +e
   no_recompilation_path="test/src/main/scala/scalarules/test/strict_deps/no_recompilation"
@@ -146,46 +87,7 @@ test_scala_library_expect_no_java_recompilation_on_internal_change_of_scala_sibl
   test_scala_library_expect_no_recompilation_on_internal_change "B.scala" "s/println(\"orig_sibling\")/println(\"altered_sibling\")/" "/dependency_java" "java sibling"
 }
 
-test_scala_library_expect_failure_on_missing_direct_java() {
-  dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
-
-  expected_message="$dependency_target.*$test_target"
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
-}
-
-test_scala_library_expect_better_failure_with_target_label_from_stamped_jar_on_missing_transitive_dependency() {
-  transitive_target='.*transitive_dependency-ijar.jar'
-  direct_target='//test_expect_failure/missing_direct_deps/internal_deps:direct_java_provider_dependency'
-  test_target='//test_expect_failure/missing_direct_deps/internal_deps:dependent_on_some_java_provider'
-
-  expected_message='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
-}
-
-test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules() {
-  transitive_target='.*transitive_dependency_without_manifest.jar'
-  direct_target='@@?//test_expect_failure/missing_direct_deps/internal_deps:unstamped_direct_java_provider_dependency'
-  test_target='//test_expect_failure/missing_direct_deps/internal_deps:unstamped_jar_dependent_on_some_java_provider'
-
-  expected_message="Unknown label of file $transitive_target which came from $direct_target"
-
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
-}
-
-$runner test_scala_library_expect_failure_on_missing_direct_internal_deps
-$runner test_scala_library_expect_failure_on_missing_direct_external_deps_jar
-$runner test_scala_library_expect_failure_on_missing_direct_external_deps_file_group
-$runner test_scala_library_expect_failure_on_missing_direct_deps_strict_is_disabled_by_default
-$runner test_scala_library_expect_failure_on_missing_direct_deps_warn_mode
-$runner test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java
-$runner test_scala_library_expect_failure_on_missing_direct_deps_off_mode
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_dependency
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_scala_dependency
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_java_dependency
 $runner test_scala_library_expect_no_java_recompilation_on_internal_change_of_scala_sibling
-$runner test_scala_library_expect_failure_on_missing_direct_java
-$runner test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules
-$runner test_scala_library_expect_better_failure_with_target_label_from_stamped_jar_on_missing_transitive_dependency


### PR DESCRIPTION
### Description

Moves the 10 missing-direct-deps checks from `test_scala_library.sh` into `test/missing_direct_deps/BUILD` as `expect_build_failure_test`/`expect_build_success_test` targets, covering each strict-deps mode (error, warn, off, default) plus the two custom-Java-provider label cases.

The fixture stays at `test_expect_failure/missing_direct_deps/` (not colocated): two other in-flight branches still migrate shell files that use it. Colocation is a follow-up once all three land.

The "off mode" case now asserts `not found: value C` instead of the original path+line message (which had a separate Windows variant): the new macro only does substring matching, not regex, so it can't branch on OS. Still confirms the intended behavior, a raw compiler error instead of a buildozer hint.

### Motivation

Deletes the 10 functions and their `$runner` lines; the file's 4 recompilation tests are untouched.

Release impact: tests only.