### PR TITLE
refactor: Migrate scala_binary missing-direct-deps tests to Bazel

### DIFF
--- a/test/scala_binary_missing_direct_deps/BUILD
+++ b/test/scala_binary_missing_direct_deps/BUILD
@@ -1,0 +1,17 @@
+load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
+
+_MISSING_DIRECT_DEPS_TOOLCHAIN = "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
+
+expect_build_failure_test(
+    name = "user_binary_missing_direct_deps_test",
+    build_args = [_MISSING_DIRECT_DEPS_TOOLCHAIN],
+    expect = ["expected_user_binary_buildozer_message.txt"],
+    target = "//test_expect_failure/missing_direct_deps/internal_deps:user_binary",
+)
+
+expect_build_failure_test(
+    name = "binary_user_of_binary_missing_direct_deps_test",
+    build_args = [_MISSING_DIRECT_DEPS_TOOLCHAIN],
+    expect = ["expected_binary_user_of_binary_buildozer_message.txt"],
+    target = "//test_expect_failure/missing_direct_deps/internal_deps:binary_user_of_binary",
+)

--- a/test/scala_binary_missing_direct_deps/expected_binary_user_of_binary_buildozer_message.txt
+++ b/test/scala_binary_missing_direct_deps/expected_binary_user_of_binary_buildozer_message.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency' //test_expect_failure/missing_direct_deps/internal_deps:binary_user_of_binary

--- a/test/scala_binary_missing_direct_deps/expected_user_binary_buildozer_message.txt
+++ b/test/scala_binary_missing_direct_deps/expected_user_binary_buildozer_message.txt
@@ -1,0 +1,1 @@
+buildozer 'add deps //test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency' //test_expect_failure/missing_direct_deps/internal_deps:user_binary

--- a/test/shell/test_scala_binary.sh
+++ b/test/shell/test_scala_binary.sh
@@ -4,20 +4,6 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
-test_scala_binary_expect_failure_on_missing_direct_deps() {
-  dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  test_target='test_expect_failure/missing_direct_deps/internal_deps:user_binary'
-
-  test_scala_library_expect_failure_on_missing_direct_deps ${dependency_target} ${test_target}
-}
-
-test_scala_binary_expect_failure_on_missing_direct_deps_located_in_dependency_which_is_scala_binary() {
-  dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  test_target='test_expect_failure/missing_direct_deps/internal_deps:binary_user_of_binary'
-
-  test_scala_library_expect_failure_on_missing_direct_deps ${dependency_target} ${test_target}
-}
-
 test_scala_binary_allows_opt_in_to_use_of_argument_file_in_runner_for_improved_performance() {
 
   bazel run --extra_toolchains="//test/toolchains:use_argument_file_in_runner" //test/src/main/scala/scalarules/test/large_classpath:largeClasspath
@@ -36,9 +22,6 @@ test_scala_binary_allows_opt_in_to_use_of_argument_file_in_runner_for_improved_p
   fi
 
 }
-
-$runner test_scala_binary_expect_failure_on_missing_direct_deps
-$runner test_scala_binary_expect_failure_on_missing_direct_deps_located_in_dependency_which_is_scala_binary
 
 if !  is_windows; then
   #rules_scala doesn't support argfiles on windows yet


### PR DESCRIPTION
### Description

Moves the two missing-direct-deps cases out of `test_scala_binary.sh` into `test/scala_binary_missing_direct_deps/BUILD` as `expect_build_failure_test` targets, both driven under the `high_level_transitive_deps_strict_deps_error` toolchain and asserting the buildozer hint. They reuse the existing `user_binary` and `binary_user_of_binary` fixtures in `test_expect_failure/missing_direct_deps/internal_deps` rather than adding new ones. The second case checks that the same hint is reported correctly when the missing-dep chain runs through a `scala_binary`-to-`scala_binary` dependency, not just library-to-library.

The fixture stays at `test_expect_failure/missing_direct_deps/` on purpose, not colocated here: `test_strict_dependency.sh` still references it from another in-flight branch. Colocation is a follow-up once that lane lands too.

### Motivation

Deletes the two functions and their `$runner` lines from `test_scala_binary.sh`. The file's other case, the argfile-runner test, is untouched.

Release impact: tests only.