### PR TITLE
test: Add `bazel_arg_files` to `expect_build_failure.bzl` macros

### DIFF
--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -47,6 +47,7 @@ def _nested_bazel_test(
         reject,
         size,
         tags,
+        bazel_arg_files = [],
         **kwargs):
     args = ["--command", command, "--target", _absolutize(target)]
     if expect_success:
@@ -71,6 +72,10 @@ def _nested_bazel_test(
         if " " in bazel_arg:
             bazel_arg = "'%s'" % bazel_arg
         args += ["--bazel-arg", bazel_arg]
+    for bazel_arg_file in bazel_arg_files:
+        # The flag's value lives in the file, so only its (metacharacter-free)
+        # path rides the `sh_test` args here -- see the helper's --bazel-arg-file.
+        args += ["--bazel-arg-file", "$(rootpath %s)" % bazel_arg_file]
     for expect_file in expect:
         args += ["--expect-file", "$(rootpath %s)" % expect_file]
     for reject_file in reject:
@@ -107,7 +112,7 @@ def _nested_bazel_test(
     data = [
         "//:MODULE.bazel",
         _NESTED_BAZEL_LIB,
-    ] + expect + reject + code_under_test + kwargs.pop("data", [])
+    ] + expect + reject + bazel_arg_files + code_under_test + kwargs.pop("data", [])
 
     # De-duplicate by canonical label: `code_under_test` re-lists files that are
     # also named explicitly (e.g. the expect/reject `.txt`s, passed as `:foo.txt`),
@@ -300,6 +305,7 @@ def expect_test_success_test(
         name,
         target,
         bazel_args = [],
+        bazel_arg_files = [],
         env = {},
         worker_sandboxing = False,
         expect = [],
@@ -323,6 +329,13 @@ def expect_test_success_test(
             would run it without them and fail.
         bazel_args: extra flags forwarded verbatim to the nested `bazel test`
             (e.g. `"--test_filter=A"`).
+        bazel_arg_files: file labels each holding one extra flag as its
+            (newline-stripped) contents, forwarded to the nested `bazel test`
+            just like `bazel_args`. Use this instead of `bazel_args` for a flag
+            whose value the `sh_test` args pipeline would mangle -- a space, or a
+            shell metacharacter the Windows launcher's `bash -c` would interpret
+            (e.g. a `--test_filter` regex containing `(`/`|`/`$`). Automatically
+            added to the test's `data`.
         env: dict of KEY: VALUE exported into the nested `bazel` client env before
             the run (e.g. to feed the target's `env_inherit`).
         worker_sandboxing: see `expect_build_failure_test`.
@@ -339,6 +352,7 @@ def expect_test_success_test(
         command = "test",
         target = target,
         bazel_args = bazel_args,
+        bazel_arg_files = bazel_arg_files,
         expect_success = True,
         env = env,
         worker_sandboxing = worker_sandboxing,

--- a/test/expect_build_failure/expect_build_failure.sh
+++ b/test/expect_build_failure/expect_build_failure.sh
@@ -13,6 +13,7 @@
 #       [--expect-success] \
 #       [--env <KEY=VALUE>]... \
 #       [--bazel-arg <flag>]... \
+#       [--bazel-arg-file <path>]... \
 #       [--expect-file <path>]... \
 #       [--reject-file <path>]...
 #
@@ -25,6 +26,12 @@
 #   --bazel-arg       extra option forwarded to the nested `bazel <command>` (e.g.
 #                     `--repo_env=SCALA_VERSION=2.13.18` or `--extra_toolchains=...`);
 #                     repeatable.
+#   --bazel-arg-file  like --bazel-arg, but the (newline-stripped) contents of the
+#                     given file are the flag. Use this for a flag whose value
+#                     Bazel's `sh_test` args pipeline would mangle -- a space (see
+#                     the note below) or a shell metacharacter that the Windows
+#                     launcher's `bash -c` would interpret (e.g. a `--test_filter`
+#                     regex with `(`/`|`/`$`); repeatable.
 #   --clean-before-build  run `bazel clean` (no --expunge) against the nested
 #                     output base before the real invocation. The caller
 #                     (expect_build_success_test) passes this whenever it also
@@ -57,6 +64,7 @@ command="build"
 expect_success="false"
 clean_before_build="false"
 bazel_args=()
+bazel_arg_files=()
 expect_files=()
 reject_files=()
 
@@ -86,6 +94,10 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --bazel-arg)
       bazel_args+=("$2")
+      shift 2
+      ;;
+    --bazel-arg-file)
+      bazel_arg_files+=("$2")
       shift 2
       ;;
     --expect-file)
@@ -129,6 +141,13 @@ _resolve_message_file() {
 }
 
 nested_bazel_setup "rules_scala_expect_build_failure_output_base"
+
+# Append file-backed flags (see --bazel-arg-file). Read here, after parsing, so
+# the shell never has to carry the raw value on a command line.
+for bazel_arg_file in ${bazel_arg_files[@]+"${bazel_arg_files[@]}"}; do
+  resolved="$(_resolve_message_file "${bazel_arg_file}")"
+  bazel_args+=("$(tr -d '\n' <"${resolved}")")
+done
 
 if [[ "${clean_before_build}" == "true" ]]; then
   nested_bazel_run clean >/dev/null 2>&1


### PR DESCRIPTION
### Description

Add a `bazel_arg_files` attribute to the `expect_build_failure.bzl` macros (and a matching `--bazel-arg-file` option to `expect_build_failure.sh`) that reads a nested-Bazel flag's value from a file, so only the file's (metacharacter-free) path travels on the `sh_test` command line and the raw value is read from disk after arg parsing.

### Motivation

Some Bazel flags can't safely ride the `sh_test` args list: a value containing a space, or a shell metacharacter that the Windows launcher's `bash -c` reinterprets (e.g. a `--test_filter` regex with `(`/`|`/`$`). Routing such flags through a file avoids that mangling. Extracted as the base of #1917, whose migrated `--test_filter` test needs it to keep the upstream cross-class alternation regex.