### PR TITLE
test: Add expect_regex/reject_regex to expect_build_failure_test/expect_build_success_test

### DIFF
--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -15,6 +15,12 @@ runfiles, and boilerplate tags on every call.
   only passes under a specific `--test_filter` or inherited env var).
 
 All four share the same script and nested-Bazel plumbing.
+
+A label inside a `build_args`/`bazel_args` flag value (e.g.
+`--extra_toolchains=//pkg:toolchain`) is passed through as-is: unlike
+`target`, it is not absolutized against the caller's package, because the
+nested `bazel` runs from the workspace root. Always write such a label out in
+full, even for a toolchain defined in the same package as the caller.
 """
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -47,6 +53,8 @@ def _nested_bazel_test(
         reject,
         size,
         tags,
+        expect_regex = [],
+        reject_regex = [],
         **kwargs):
     args = ["--command", command, "--target", _absolutize(target)]
     if expect_success:
@@ -54,7 +62,7 @@ def _nested_bazel_test(
 
         # Without a clean, a cached build can silently skip recompiling and
         # miss printing the warning we're about to check for.
-        if expect or reject:
+        if expect or reject or expect_regex or reject_regex:
             args += ["--clean-before-build"]
     for key in env:
         value = env[key]
@@ -75,6 +83,10 @@ def _nested_bazel_test(
         args += ["--expect-file", "$(rootpath %s)" % expect_file]
     for reject_file in reject:
         args += ["--reject-file", "$(rootpath %s)" % reject_file]
+    for expect_regex_file in expect_regex:
+        args += ["--expect-regex-file", "$(rootpath %s)" % expect_regex_file]
+    for reject_regex_file in reject_regex:
+        args += ["--reject-regex-file", "$(rootpath %s)" % reject_regex_file]
     if worker_sandboxing:
         args = args + select({
             "@platforms//os:windows": [],
@@ -107,7 +119,7 @@ def _nested_bazel_test(
     data = [
         "//:MODULE.bazel",
         _NESTED_BAZEL_LIB,
-    ] + expect + reject + code_under_test + kwargs.pop("data", [])
+    ] + expect + reject + expect_regex + reject_regex + code_under_test + kwargs.pop("data", [])
 
     # De-duplicate by canonical label: `code_under_test` re-lists files that are
     # also named explicitly (e.g. the expect/reject `.txt`s, passed as `:foo.txt`),
@@ -146,6 +158,8 @@ def expect_build_failure_test(
         worker_sandboxing = False,
         expect = [],
         reject = [],
+        expect_regex = [],
+        reject_regex = [],
         size = "large",
         tags = ["local", "requires-network"],
         **kwargs):
@@ -169,6 +183,14 @@ def expect_build_failure_test(
             build output. Automatically added to the test's `data`.
         reject: file labels whose (newline-stripped) contents must NOT appear in
             the build output. Automatically added to the test's `data`.
+        expect_regex: file labels whose (newline-stripped) contents is an
+            extended regex that must match the build output. Use only when the
+            exact text isn't stable across the Bazel-version matrix this test
+            runs under (e.g. a bzlmod canonical repo name); prefer `expect` for
+            anything that is otherwise a fixed string. Automatically added to
+            the test's `data`.
+        reject_regex: same as `expect_regex`, but the regex must NOT match.
+            Automatically added to the test's `data`.
         size: test size; defaults to `"large"` (the nested Bazel invocation is
             slow and, on a cold cache, serializes on the shared output base).
         tags: test tags; defaults to `["local", "requires-network"]` because the
@@ -186,6 +208,8 @@ def expect_build_failure_test(
         worker_sandboxing = worker_sandboxing,
         expect = expect,
         reject = reject,
+        expect_regex = expect_regex,
+        reject_regex = reject_regex,
         size = size,
         tags = tags,
         **kwargs
@@ -198,6 +222,8 @@ def expect_build_success_test(
         worker_sandboxing = False,
         expect = [],
         reject = [],
+        expect_regex = [],
+        reject_regex = [],
         size = "large",
         tags = ["local", "requires-network"],
         **kwargs):
@@ -227,6 +253,10 @@ def expect_build_success_test(
             build output. Automatically added to the test's `data`.
         reject: file labels whose (newline-stripped) contents must NOT appear in
             the build output. Automatically added to the test's `data`.
+        expect_regex: see `expect_build_failure_test`. Automatically added to
+            the test's `data`.
+        reject_regex: see `expect_build_failure_test`. Automatically added to
+            the test's `data`.
         size: test size; defaults to `"large"`.
         tags: test tags; defaults to `["local", "requires-network"]`.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
@@ -241,6 +271,8 @@ def expect_build_success_test(
         worker_sandboxing = worker_sandboxing,
         expect = expect,
         reject = reject,
+        expect_regex = expect_regex,
+        reject_regex = reject_regex,
         size = size,
         tags = tags,
         **kwargs

--- a/test/expect_build_failure/expect_build_failure.sh
+++ b/test/expect_build_failure/expect_build_failure.sh
@@ -38,6 +38,15 @@
 #                     output; repeatable.
 #   --reject-file     file whose (newline-stripped) contents must NOT appear in the
 #                     output; repeatable.
+#   --expect-regex-file  file whose (newline-stripped) contents is an extended
+#                     regex (grep -E) that must match the output; repeatable.
+#                     Use only when the exact text is not stable across the
+#                     Bazel-version matrix this test runs under (e.g. a bzlmod
+#                     canonical repo name, whose `~`/`+` separator and version
+#                     suffix vary by Bazel version) -- prefer --expect-file for
+#                     anything that is otherwise a fixed string.
+#   --reject-regex-file  same as --expect-regex-file, but the regex must NOT
+#                     match; repeatable.
 #
 # Messages are passed as files rather than inline strings because Bazel subjects
 # `sh_test` `args` to Bourne tokenization, which would split messages that
@@ -59,6 +68,8 @@ clean_before_build="false"
 bazel_args=()
 expect_files=()
 reject_files=()
+expect_regex_files=()
+reject_regex_files=()
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
@@ -94,6 +105,14 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --reject-file)
       reject_files+=("$2")
+      shift 2
+      ;;
+    --expect-regex-file)
+      expect_regex_files+=("$2")
+      shift 2
+      ;;
+    --reject-regex-file)
+      reject_regex_files+=("$2")
       shift 2
       ;;
     *)
@@ -150,26 +169,44 @@ if [[ "${expect_success}" != "true" && "${status}" -eq 0 ]]; then
   exit 1
 fi
 
-for expect_file in ${expect_files[@]+"${expect_files[@]}"}; do
-  resolved="$(_resolve_message_file "${expect_file}")"
-  expected_message="$(tr -d '\n' <"${resolved}")"
-  if ! grep --quiet --fixed-strings -- "${expected_message}" <<<"${output}"; then
-    echo "Nested \`bazel ${command}\` finished as expected, but output did not contain the expected message." >&2
-    echo "Expected (from ${expect_file}): ${expected_message}" >&2
-    echo "Output:" >&2
-    echo "${output}" >&2
-    exit 1
-  fi
-done
+# Checks each file in $4... against $output, using $2 as the grep mode
+# (--fixed-strings or --extended-regexp) and failing if a match is found ($3
+# "true") or missing ($3 "false"). $1 ("message"/"regex") only picks the
+# wording of the failure output.
+_check_files() {
+  local kind="$1"
+  local grep_mode="$2"
+  local must_match="$3"
+  shift 3
 
-for reject_file in ${reject_files[@]+"${reject_files[@]}"}; do
-  resolved="$(_resolve_message_file "${reject_file}")"
-  rejected_message="$(tr -d '\n' <"${resolved}")"
-  if grep --quiet --fixed-strings -- "${rejected_message}" <<<"${output}"; then
-    echo "Nested \`bazel ${command}\` finished as expected, but output contained a message that should be absent." >&2
-    echo "Rejected (from ${reject_file}): ${rejected_message}" >&2
+  local file resolved text matched
+  for file in "$@"; do
+    resolved="$(_resolve_message_file "${file}")"
+    text="$(tr -d '\n' <"${resolved}")"
+
+    if grep --quiet "${grep_mode}" -- "${text}" <<<"${output}"; then
+      matched="true"
+    else
+      matched="false"
+    fi
+    if [[ "${matched}" == "${must_match}" ]]; then
+      continue
+    fi
+
+    if [[ "${must_match}" == "true" ]]; then
+      echo "Nested \`bazel ${command}\` finished as expected, but output did not contain the expected ${kind}." >&2
+      echo "Expected (from ${file}): ${text}" >&2
+    else
+      echo "Nested \`bazel ${command}\` finished as expected, but output contained a ${kind} that should be absent." >&2
+      echo "Rejected (from ${file}): ${text}" >&2
+    fi
     echo "Output:" >&2
     echo "${output}" >&2
     exit 1
-  fi
-done
+  done
+}
+
+_check_files "message" --fixed-strings true ${expect_files[@]+"${expect_files[@]}"}
+_check_files "message" --fixed-strings false ${reject_files[@]+"${reject_files[@]}"}
+_check_files "regex" --extended-regexp true ${expect_regex_files[@]+"${expect_regex_files[@]}"}
+_check_files "regex" --extended-regexp false ${reject_regex_files[@]+"${reject_regex_files[@]}"}


### PR DESCRIPTION
### Description

Adds `expect_regex`/`reject_regex` (matched with `grep -E`, not `--fixed-strings`) to `expect_build_failure_test`/`expect_build_success_test`.

Some buildozer messages aren't a fixed string across the Bazel-version matrix this suite runs under: a bzlmod module-extension repo's canonical name uses `~` or `+` depending on Bazel version, and a self-repo label sometimes gets a leading `@@`. Split out of #1915 per review.

### Motivation

#1915 depends on this merging first -- it uses `expect_regex` for 4 of its 12 checks. Release impact: none by itself.