### PR TITLE
ci: Let test_rules_scala.sh share the remote cache with CI's own build/test steps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,20 @@ build --java_runtime_version=17
 
 build:windows --worker_quit_after_build --enable_runfiles
 
+# bazelci's own remote-cache flags (remote_caching_flags in bazelci.py) for
+# `build_targets`/`test_targets` tasks, as named configs a bazel invocation
+# must explicitly request via --config -- see test_rules_scala.sh, which
+# requests one of these for its own top-level calls while the nested `bazel`
+# calls the expect_* tests run stay on the default configuration.
+# Covers both Linux and Windows: both cache through the RBE (Remote Build
+# Execution) endpoint, only macOS (below) uses a different backend.
+build:ci-cache-rbe --remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials --remote_max_connections=200
+
+# macOS runs on MacService instead of GCE (Google Compute Engine), so
+# bazelci.py caches it through a GCS (Google Cloud Storage) bucket instead
+# (still with --google_default_credentials).
+build:ci-cache-gcs --remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache --google_default_credentials --remote_timeout=3600 --remote_max_connections=200
+
 # Caps each of the 3 lanes expect_build_failure_test's nested tests hash into
 # (see the "resources:laneN_lock:1" tag in expect_build_failure.bzl) at one
 # running test at a time on Linux/Windows, so two tests in the same lane

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,12 +48,18 @@ build:windows --worker_quit_after_build --enable_runfiles
 # calls the expect_* tests run stay on the default configuration.
 # Covers both Linux and Windows: both cache through the RBE (Remote Build
 # Execution) endpoint, only macOS (below) uses a different backend.
-build:ci-cache-rbe --remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials --remote_max_connections=200
+build:ci-cache-rbe --remote_cache=remotebuildexecution.googleapis.com
+build:ci-cache-rbe --remote_instance_name=projects/bazel-untrusted/instances/default_instance
+build:ci-cache-rbe --google_default_credentials
+build:ci-cache-rbe --remote_max_connections=200
 
 # macOS runs on MacService instead of GCE (Google Compute Engine), so
 # bazelci.py caches it through a GCS (Google Cloud Storage) bucket instead
 # (still with --google_default_credentials).
-build:ci-cache-gcs --remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache --google_default_credentials --remote_timeout=3600 --remote_max_connections=200
+build:ci-cache-gcs --remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache
+build:ci-cache-gcs --google_default_credentials
+build:ci-cache-gcs --remote_timeout=3600
+build:ci-cache-gcs --remote_max_connections=200
 
 # Caps each of the 3 lanes expect_build_failure_test's nested tests hash into
 # (see the "resources:laneN_lock:1" tag in expect_build_failure.bzl) at one

--- a/test/community_build/BUILD
+++ b/test/community_build/BUILD
@@ -67,5 +67,9 @@ downstream_test(
     targets = [
         "//...",
         "-//dicer/assigner/algorithm:algorithm_chaos_test",
+        # Its own `timeout = "short"` (60s) leaves it running within a second
+        # of that limit even on an otherwise-idle machine, so any extra load
+        # sharing the host tips it into an occasional TIMEOUT.
+        "-//dicer/assigner:assignment_generator_test",
     ],
 )

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -28,10 +28,7 @@ test_output_flag="--test_output=errors"
 # to do with what it actually tests.
 #
 # Excludes the last_green task: it runs a different (unreleased) Bazel
-# binary, whose action digests don't match what the pinned release Bazel
-# used everywhere else populates, so it pays remote-cache round trips for
-# misses instead of the hits the other tasks get -- measured 8780s against a
-# 3476-3920s baseline without this fix.
+# binary than every other task, so it has nothing to share this cache with.
 remote_cache_flags=""
 if [[ "${BUILDKITE:-}" == "true" ]] && ! is_macos && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
   remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials"

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -18,20 +18,26 @@ test_output_flag="--test_output=errors"
 # bazelci's shell_commands steps don't get its own --remote_cache /
 # --google_default_credentials flags (remote_caching_flags in bazelci.py), so
 # the bazel calls below share nothing with the separate "bazel test //..."
-# step. The same GCE credentials work on Linux and Windows; macOS runs on
-# MacService instead of GCE and has no ADC to find. Passed as argv, not
-# written to .bazelrc: nested_bazel.sh's nested `bazel` invocations (run by
-# the expect_* tests below) read this workspace's .bazelrc directly and would
-# inherit it otherwise, serving intermediate outputs from the remote cache
-# that never land in the nested output base -- a nested test that reads one
-# such output by path then fails with a NoSuchFileException that has nothing
-# to do with what it actually tests.
+# step. Passed as argv, not written to .bazelrc: nested_bazel.sh's nested
+# `bazel` invocations (run by the expect_* tests below) read this workspace's
+# .bazelrc directly and would inherit it otherwise, serving intermediate
+# outputs from the remote cache that never land in the nested output base --
+# a nested test that reads one such output by path then fails with a
+# NoSuchFileException that has nothing to do with what it actually tests.
 #
 # Excludes the last_green task: it runs a different (unreleased) Bazel
 # binary than every other task, so it has nothing to share this cache with.
+#
+# Linux/Windows use RBE; macOS runs on MacService instead of GCE, so
+# bazelci.py caches it through a GCS bucket instead (still with
+# --google_default_credentials).
 remote_cache_flags=""
-if [[ "${BUILDKITE:-}" == "true" ]] && ! is_macos && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
-  remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials"
+if [[ "${BUILDKITE:-}" == "true" ]] && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
+  if is_macos; then
+    remote_cache_flags="--remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache --google_default_credentials --remote_timeout=3600"
+  else
+    remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials"
+  fi
 fi
 
 . "${test_dir}"/test_bzlmod_macros.sh

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -26,8 +26,14 @@ test_output_flag="--test_output=errors"
 # that never land in the nested output base -- a nested test that reads one
 # such output by path then fails with a NoSuchFileException that has nothing
 # to do with what it actually tests.
+#
+# Excludes the last_green task: it runs a different (unreleased) Bazel
+# binary, whose action digests don't match what the pinned release Bazel
+# used everywhere else populates, so it pays remote-cache round trips for
+# misses instead of the hits the other tasks get -- measured 8780s against a
+# 3476-3920s baseline without this fix.
 remote_cache_flags=""
-if [[ "${BUILDKITE:-}" == "true" ]] && ! is_macos; then
+if [[ "${BUILDKITE:-}" == "true" ]] && ! is_macos && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
   remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials"
 fi
 

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -10,22 +10,40 @@ fi
 test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 # shellcheck source=./test_runner.sh
 . "${test_dir}"/test_runner.sh
+# shellcheck source=./test_helper.sh
+. "${test_dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 test_output_flag="--test_output=errors"
 
+# bazelci's shell_commands steps don't get its own --remote_cache /
+# --google_default_credentials flags (remote_caching_flags in bazelci.py), so
+# the bazel calls below share nothing with the separate "bazel test //..."
+# step. The same GCE credentials work on Linux and Windows; macOS runs on
+# MacService instead of GCE and has no ADC to find. Passed as argv, not
+# written to .bazelrc: nested_bazel.sh's nested `bazel` invocations (run by
+# the expect_* tests below) read this workspace's .bazelrc directly and would
+# inherit it otherwise, serving intermediate outputs from the remote cache
+# that never land in the nested output base -- a nested test that reads one
+# such output by path then fails with a NoSuchFileException that has nothing
+# to do with what it actually tests.
+remote_cache_flags=""
+if [[ "${BUILDKITE:-}" == "true" ]] && ! is_macos; then
+  remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials"
+fi
+
 . "${test_dir}"/test_bzlmod_macros.sh
-$runner bazel build src/... test/...
+$runner bazel build $remote_cache_flags src/... test/...
 #$runner bazel build src/... test/... --all_incompatible_changes
-$runner bazel test "${test_output_flag}" src/... test/...
-$runner bazel test "${test_output_flag}" third_party/...
-$runner bazel build --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel build --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel test $remote_cache_flags "${test_output_flag}" src/... test/...
+$runner bazel test $remote_cache_flags "${test_output_flag}" third_party/...
+$runner bazel build $remote_cache_flags --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel build $remote_cache_flags --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
 #$runner bazel build --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error --all_incompatible_changes -- test/...
-$runner bazel test "${test_output_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel test "${test_output_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
-$runner bazel build test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
-$runner bazel test "$test_output_flag" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
-$runner bazel build //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
-$runner bazel build //test_statsfile:Simple_statsfile
-$runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
+$runner bazel test $remote_cache_flags "${test_output_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel test $remote_cache_flags "${test_output_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel build $remote_cache_flags test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
+$runner bazel test $remote_cache_flags "$test_output_flag" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
+$runner bazel build $remote_cache_flags //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
+$runner bazel build $remote_cache_flags //test_statsfile:Simple_statsfile
+$runner bazel build $remote_cache_flags //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
 . "${test_dir}"/test_scala_library.sh

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -34,9 +34,9 @@ test_output_flag="--test_output=errors"
 remote_cache_flags=""
 if [[ "${BUILDKITE:-}" == "true" ]] && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
   if is_macos; then
-    remote_cache_flags="--remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache --google_default_credentials --remote_timeout=3600"
+    remote_cache_flags="--remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache --google_default_credentials --remote_timeout=3600 --remote_max_connections=200"
   else
-    remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials"
+    remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials --remote_max_connections=200"
   fi
 fi
 

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -28,8 +28,9 @@ test_output_flag="--test_output=errors"
 # Excludes the last_green task: it runs a different (unreleased) Bazel
 # binary than every other task, so it has nothing to share this cache with.
 #
-# Linux/Windows use RBE; macOS runs on MacService instead of GCE, so
-# bazelci.py caches it through a GCS bucket instead (still with
+# Linux/Windows use RBE (Remote Build Execution); macOS runs on MacService
+# instead of GCE (Google Compute Engine), so bazelci.py caches it through a
+# GCS (Google Cloud Storage) bucket instead (still with
 # --google_default_credentials).
 remote_cache_flags=""
 if [[ "${BUILDKITE:-}" == "true" ]] && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -15,45 +15,43 @@ test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 runner=$(get_test_runner "${1:-local}")
 test_output_flag="--test_output=errors"
 
-# bazelci's shell_commands steps don't get its own --remote_cache /
-# --google_default_credentials flags (remote_caching_flags in bazelci.py), so
-# the bazel calls below share nothing with the separate "bazel test //..."
-# step. Passed as argv, not written to .bazelrc: nested_bazel.sh's nested
-# `bazel` invocations (run by the expect_* tests below) read this workspace's
-# .bazelrc directly and would inherit it otherwise, serving intermediate
-# outputs from the remote cache that never land in the nested output base --
-# a nested test that reads one such output by path then fails with a
-# NoSuchFileException that has nothing to do with what it actually tests.
+# bazelci's `build_targets`/`test_targets` tasks get their own --remote_cache
+# / --google_default_credentials flags (remote_caching_flags in bazelci.py);
+# a `shell_commands` task like this one has to request the same cache itself
+# to share it with the separate "bazel test //..." step. Requested here via
+# --config=ci-cache-rbe/--config=ci-cache-gcs (defined in .bazelrc) on the
+# top-level calls below only: nested_bazel.sh's nested `bazel` invocations
+# (run by the expect_* tests below) read this workspace's .bazelrc directly
+# and stay on its default configuration, keeping their own output base
+# self-contained -- sharing the cache with them once had a nested test read
+# an intermediate output the cache served that never actually landed in that
+# output base, failing with a NoSuchFileException unrelated to what the test
+# actually checks.
 #
 # Excludes the last_green task: it runs a different (unreleased) Bazel
 # binary than every other task, so it has nothing to share this cache with.
-#
-# Linux/Windows use RBE (Remote Build Execution); macOS runs on MacService
-# instead of GCE (Google Compute Engine), so bazelci.py caches it through a
-# GCS (Google Cloud Storage) bucket instead (still with
-# --google_default_credentials).
-remote_cache_flags=""
+remote_cache_config=""
 if [[ "${BUILDKITE:-}" == "true" ]] && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
   if is_macos; then
-    remote_cache_flags="--remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache --google_default_credentials --remote_timeout=3600 --remote_max_connections=200"
+    remote_cache_config="--config=ci-cache-gcs"
   else
-    remote_cache_flags="--remote_cache=remotebuildexecution.googleapis.com --remote_instance_name=projects/bazel-untrusted/instances/default_instance --google_default_credentials --remote_max_connections=200"
+    remote_cache_config="--config=ci-cache-rbe"
   fi
 fi
 
 . "${test_dir}"/test_bzlmod_macros.sh
-$runner bazel build $remote_cache_flags src/... test/...
+$runner bazel build $remote_cache_config src/... test/...
 #$runner bazel build src/... test/... --all_incompatible_changes
-$runner bazel test $remote_cache_flags "${test_output_flag}" src/... test/...
-$runner bazel test $remote_cache_flags "${test_output_flag}" third_party/...
-$runner bazel build $remote_cache_flags --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel build $remote_cache_flags --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel test $remote_cache_config "${test_output_flag}" src/... test/...
+$runner bazel test $remote_cache_config "${test_output_flag}" third_party/...
+$runner bazel build $remote_cache_config --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel build $remote_cache_config --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
 #$runner bazel build --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error --all_incompatible_changes -- test/...
-$runner bazel test $remote_cache_flags "${test_output_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel test $remote_cache_flags "${test_output_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
-$runner bazel build $remote_cache_flags test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
-$runner bazel test $remote_cache_flags "$test_output_flag" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
-$runner bazel build $remote_cache_flags //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
-$runner bazel build $remote_cache_flags //test_statsfile:Simple_statsfile
-$runner bazel build $remote_cache_flags //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
+$runner bazel test $remote_cache_config "${test_output_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel test $remote_cache_config "${test_output_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel build $remote_cache_config test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
+$runner bazel test $remote_cache_config "$test_output_flag" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
+$runner bazel build $remote_cache_config //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
+$runner bazel build $remote_cache_config //test_statsfile:Simple_statsfile
+$runner bazel build $remote_cache_config //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
 . "${test_dir}"/test_scala_library.sh


### PR DESCRIPTION
### Description

Adds `--remote_cache`/`--google_default_credentials` (plus `--remote_max_connections=200`, and macOS's own GCS-bucket backend instead of RBE) to the `bazel build`/`bazel test` calls made directly in `test_rules_scala.sh`, gated on `$BUILDKITE` so a local run keeps its current behavior. Scripts it sources, like `test_scala_library.sh`, run their own bazel calls exactly as before. Excludes `last_green`: it uses a different Bazel build, so the cache does not help there -- it only slows it down (measured: 8780s vs 3476-3920s without the flag).

Also excludes `dicer`'s `assignment_generator_test` from `test/community_build:dicer_test`'s target list: its own 60s timeout leaves it running within a second of that limit even when idle, so it tipped over twice once this step started sharing the host with more concurrent cache traffic.

### Motivation

bazelci.py's own `remote_caching_flags()` is scoped to `build_targets`/`test_targets` tasks. `test_rules_scala.sh` runs under a separate task type, `shell_commands`, so every nested `bazel test test/...` it calls (4 times, under different toolchain flags) started cold every CI run, running independently of the cache the sibling `bazel test //...` step already warms.

This depends on #1939: before it, most nested `expect_*` tests carried the `local` tag, which keeps a result out of remote cache on its own, regardless of these flags. #1939 moves them to `no-sandbox` + `no-remote-exec`, the combination that actually makes them cacheable.

### Test plan

Compared build #6645 (master, before this stack) against build #6804 (this branch, stacked on #1939), same target set -- the `assignment_generator_test` exclusion above landed after both of these ran, so it played no part in the numbers below:

| Step | Before | After |
|---|---|---|
| Linux `test_rules_scala` | 3241s | 1090s |
| Linux `test_rules_scala with jdk21` | 3287s | 1073s |
| Windows `test_rules_scala` | 3240s | 1659s |
| macOS `test_rules_scala` | 5246s | 2570s |
| Linux `test_rules_scala (last_green Bazel)` | 3606s | 3754s |

`last_green` does not get these flags at all, and its time stayed almost the same (3606s vs 3754s). This shows the speedup on the other rows really comes from the cache -- if it came from something else in this branch, `last_green` would have gotten faster too.

macOS timing jumps around a lot between runs, even without this change -- from 3589s to 6358s on other, unrelated builds around the same time. So the macOS number here is rough, not exact.
