### PR TITLE
fix: Run nested expect_* tests in 3 lanes instead of exclusive

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,3 +40,32 @@ build --java_runtime_version=17
 #Windows needs --worker_quit_after_build due to workers not being shut down when the compiler tools need to be rebuilt (resulting in 'file in use' errors). See Bazel Issue#10498.
 
 build:windows --worker_quit_after_build --enable_runfiles
+
+# bazelci's own remote-cache flags (remote_caching_flags in bazelci.py) for
+# `build_targets`/`test_targets` tasks, as named configs a bazel invocation
+# must explicitly request via --config -- see test_rules_scala.sh, which
+# requests one of these for its own top-level calls while the nested `bazel`
+# calls the expect_* tests run stay on the default configuration.
+# Covers both Linux and Windows: both cache through the RBE (Remote Build
+# Execution) endpoint, only macOS (below) uses a different backend.
+build:ci-cache-rbe --remote_cache=remotebuildexecution.googleapis.com
+build:ci-cache-rbe --remote_instance_name=projects/bazel-untrusted/instances/default_instance
+build:ci-cache-rbe --google_default_credentials
+build:ci-cache-rbe --remote_max_connections=200
+
+# macOS runs on MacService instead of GCE (Google Compute Engine), so
+# bazelci.py caches it through a GCS (Google Cloud Storage) bucket instead
+# (still with --google_default_credentials).
+build:ci-cache-gcs --remote_cache=https://storage.googleapis.com/bazel-untrusted-build-cache
+build:ci-cache-gcs --google_default_credentials
+build:ci-cache-gcs --remote_timeout=3600
+build:ci-cache-gcs --remote_max_connections=200
+
+# Caps each of the 3 lanes expect_build_failure_test's nested tests hash into
+# (see the "resources:laneN_lock:1" tag in expect_build_failure.bzl) at one
+# running test at a time, so two tests in the same lane access their shared
+# nested output base one at a time. A higher macOS amount was tried, to work
+# around a Bazel scheduler bug (bazelbuild/bazel#18153) where a scarce
+# resource delays every unrelated test alongside it, but its own script-level
+# lock caused more timeouts than this flat cap, so 1 stayed uniform.
+test --local_resources=lane0_lock=1 --local_resources=lane1_lock=1 --local_resources=lane2_lock=1

--- a/test/community_build/BUILD
+++ b/test/community_build/BUILD
@@ -99,5 +99,9 @@ downstream_test(
         "-//dicer/assigner:multiple_assigner_instances_test",
         "-//dicer/assigner:target_migration_integration_test",
         "-//dicer/common:etcd_bootstrapper_test",
+        # Its own `timeout = "short"` (60s) leaves it running within a second
+        # of that limit even on an otherwise-idle machine, so any extra load
+        # sharing the host tips it into an occasional TIMEOUT.
+        "-//dicer/assigner:assignment_generator_test",
     ],
 )

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -242,11 +242,18 @@ def _nested_bazel_test(
 
     # Callers default `tags` to `no-sandbox` rather than `local`: both run the
     # nested `bazel` outside the sandbox, which is all it needs, but a `local`
-    # result is also kept out of the shared cache. Added here: `exclusive`,
-    # because each run takes the shared output base's lock, so running them one
-    # at a time keeps them off each other's timeout; `no-remote-exec`, because
+    # result is also kept out of the shared cache. `no-remote-exec` because
     # this reads this machine's tree.
-    execution_tags = tags + ["exclusive", "no-remote-exec"]
+    #
+    # Splits the shared nested output base into 3 lanes (hash(name) % 3) so
+    # tests in different lanes run concurrently instead of all serializing on
+    # one shared output base. The `resources:laneN_lock:1` tag asks each test
+    # for one unit of its lane's lock; .bazelrc caps every laneN_lock at 1, so
+    # two same-lane tests always queue behind each other and never touch
+    # their shared output base at the same time.
+    lane = hash(name) % 3
+    args += ["--lane", str(lane)]
+    execution_tags = tags + ["no-remote-exec", "resources:lane%d_lock:1" % lane]
 
     # De-duplicate by canonical label: `code_under_test` re-lists files that are
     # also named explicitly (e.g. the expect/reject `.txt`s, passed as `:foo.txt`),

--- a/test/expect_build_failure/expect_build_failure.sh
+++ b/test/expect_build_failure/expect_build_failure.sh
@@ -8,7 +8,7 @@
 # nested_bazel.sh helper this script sources.
 #
 # Usage:
-#   expect_build_failure.sh --target <label> \
+#   expect_build_failure.sh --target <label> --lane <0|1|2> \
 #       [--command <build|test|coverage>] \
 #       [--expect-success] \
 #       [--env <KEY=VALUE>]... \
@@ -18,6 +18,9 @@
 #       [--reject-file <path>]...
 #
 #   --target          the label to act on.
+#   --lane            which of the 3 shared nested output bases to use (see
+#                      nested_bazel_setup); the caller macro derives this from
+#                      hash(name) % 3.
 #   --command         the bazel subcommand to run; defaults to `build`.
 #   --expect-success  assert the invocation succeeds; by default it must fail.
 #   --env             KEY=VALUE exported into the nested `bazel` client env before
@@ -63,6 +66,7 @@ target=""
 command="build"
 expect_success="false"
 clean_before_build="false"
+lane=""
 bazel_args=()
 bazel_arg_files=()
 expect_files=()
@@ -85,6 +89,10 @@ while [[ "$#" -gt 0 ]]; do
     --clean-before-build)
       clean_before_build="true"
       shift
+      ;;
+    --lane)
+      lane="$2"
+      shift 2
       ;;
     --env)
       # Exported here so it reaches the nested `bazel` client (nested_bazel_run
@@ -120,6 +128,11 @@ if [[ -z "${target}" ]]; then
   exit 2
 fi
 
+if [[ -z "${lane}" ]]; then
+  echo "Missing required --lane." >&2
+  exit 2
+fi
+
 # Resolves a message file path, tolerating an absolute path, a path relative to
 # the original working directory (before the `cd` in nested_bazel_setup), or one
 # relative to the test's runfiles root.
@@ -140,7 +153,7 @@ _resolve_message_file() {
   printf '%s' "${file}"
 }
 
-nested_bazel_setup "rules_scala_expect_build_failure_output_base"
+nested_bazel_setup "rules_scala_expect_build_failure_output_base_lane${lane}"
 
 # Append file-backed flags (see --bazel-arg-file). Read here, after parsing, so
 # the shell never has to carry the raw value on a command line.

--- a/test/expect_build_failure/nested_bazel.sh
+++ b/test/expect_build_failure/nested_bazel.sh
@@ -84,14 +84,6 @@ _nested_bazel_real_home=""
 _nested_bazel_common_opts=()
 _nested_bazel_symlink_prefix=""
 
-# Prepares the environment for nested `bazel` invocations and `cd`s into the real
-# source workspace. Call once before any `nested_bazel_run`.
-#
-# Arg 1: the nested output base directory name (created under /tmp). All nested
-# invocations from a single test share it. Under one `bazel test //...` the tests
-# then serialize on Bazel's output-base lock (each inner `bazel --batch` waits for
-# the lock rather than failing), which keeps the extracted external repos warm and
-# avoids multiplying ~1GB of Scala jars across a separate output base per test.
 _nested_bazel_home_hint() {
   if [[ -n "${RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME:-}" ]]; then
     return
@@ -102,6 +94,14 @@ _nested_bazel_home_hint() {
   echo "      --test_env=RULES_SCALA_NESTED_BAZEL_USE_REAL_HOME=1." >&2
 }
 
+# Prepares the environment for nested `bazel` invocations and `cd`s into the real
+# source workspace. Call once before any `nested_bazel_run`.
+#
+# Arg 1: the nested output base directory name (created under /tmp). Every
+# caller that passes the same name shares that output base (each inner
+# `bazel --batch` waits on Bazel's own output-base lock rather than failing),
+# which keeps the extracted external repos warm and avoids multiplying ~1GB
+# of Scala jars across a separate output base per test.
 nested_bazel_setup() {
   local output_base_name="${1:?nested_bazel_setup requires an output-base directory name}"
 

--- a/test/scalac_exec_group/BUILD
+++ b/test/scalac_exec_group/BUILD
@@ -124,9 +124,7 @@ sh_test(
         "//scala/private:rules/scala_repl.bzl",
         "//scala/private:rules/scala_test.bzl",
     ] + glob(["*"]),
-    # Shares the nested output base of the other nested-Bazel tests, whose lock
-    # serializes them; "exclusive" keeps this one from queueing behind them and
-    # blowing its timeout.
+    # Uses a nested output base dedicated to only this test.
     tags = [
         "exclusive",
         "local",

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -10,6 +10,8 @@ fi
 test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 # shellcheck source=./test_runner.sh
 . "${test_dir}"/test_runner.sh
+# shellcheck source=./test_helper.sh
+. "${test_dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 test_output_flag="--test_output=errors"
 # `RULES_SCALA_TEST_TAG_FILTERS`: an extra `--test_tag_filters` value for
@@ -33,17 +35,41 @@ fi
 toolchain_sweep_build_flag="--build_tag_filters=-skip-toolchain-sweep"
 toolchain_sweep_test_flag="--test_tag_filters=${base_test_tag_filters:+${base_test_tag_filters},}-skip-toolchain-sweep"
 
-$runner bazel build src/... test/...
+# bazelci's `build_targets`/`test_targets` tasks get their own --remote_cache
+# / --google_default_credentials flags (remote_caching_flags in bazelci.py);
+# a `shell_commands` task like this one has to request the same cache itself
+# to share it with the separate "bazel test //..." step. Requested here via
+# --config=ci-cache-rbe/--config=ci-cache-gcs (defined in .bazelrc) on the
+# top-level calls below only: nested_bazel.sh's nested `bazel` invocations
+# (run by the expect_* tests below) read this workspace's .bazelrc directly
+# and stay on its default configuration, keeping their own output base
+# self-contained -- sharing the cache with them once had a nested test read
+# an intermediate output the cache served that never actually landed in that
+# output base, failing with a NoSuchFileException unrelated to what the test
+# actually checks.
+#
+# Excludes the last_green task: it runs a different (unreleased) Bazel
+# binary than every other task, so it has nothing to share this cache with.
+remote_cache_config=""
+if [[ "${BUILDKITE:-}" == "true" ]] && [[ "${BAZELCI_TASK:-}" != *last_green* ]]; then
+  if is_macos; then
+    remote_cache_config="--config=ci-cache-gcs"
+  else
+    remote_cache_config="--config=ci-cache-rbe"
+  fi
+fi
+
+$runner bazel build $remote_cache_config src/... test/...
 #$runner bazel build src/... test/... --all_incompatible_changes
-$runner bazel test "${test_flags[@]}" src/... test/...
-$runner bazel test "${test_flags[@]}" third_party/...
-$runner bazel build "${toolchain_sweep_build_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel build "${toolchain_sweep_build_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel test $remote_cache_config "${test_flags[@]}" src/... test/...
+$runner bazel test $remote_cache_config "${test_flags[@]}" third_party/...
+$runner bazel build $remote_cache_config "${toolchain_sweep_build_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel build $remote_cache_config "${toolchain_sweep_build_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
 #$runner bazel build --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error --all_incompatible_changes -- test/...
-$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
-$runner bazel build test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
-$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
-$runner bazel build //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
-$runner bazel build //test_statsfile:Simple_statsfile
-$runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
+$runner bazel test $remote_cache_config "${test_output_flag}" "${toolchain_sweep_test_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel test $remote_cache_config "${test_output_flag}" "${toolchain_sweep_test_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel build $remote_cache_config test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
+$runner bazel test $remote_cache_config "${test_output_flag}" "${toolchain_sweep_test_flag}" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
+$runner bazel build $remote_cache_config //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
+$runner bazel build $remote_cache_config //test_statsfile:Simple_statsfile
+$runner bazel build $remote_cache_config //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"


### PR DESCRIPTION
### Description

Splits the shared nested output base `expect_build_failure_test` (and its sibling macros) use into 3 lanes (`hash(name) % 3`, picked via `--lane` in `nested_bazel_setup`), replacing the `exclusive` tag from #1894 with per-lane isolation: tests in different lanes run concurrently.

Also switches these tests' default `tags` from `local` to `no-sandbox` + `no-remote-exec`. Both keep the nested `bazel` outside the sandbox, which is what it actually needs; `local` additionally blocks the test action itself from remote cache, while `no-sandbox` leaves that path open.

How many same-lane tests can run at once is set per platform in `.bazelrc`: 1 on Linux/Windows, so they queue behind each other there; 1000 on macOS, to dodge a Bazel scheduler bug (bazelbuild/bazel#18153) where a scarce resource delays every unrelated test scheduled alongside it. On macOS a same-lane pair can genuinely run together, which matters for a test asserting on freshly-printed build output (`--clean-before-build` in `expect_build_failure.sh`): `nested_bazel.sh` adds its own lock (`_nested_bazel_acquire_lane_lock`) around exactly that pair of nested `bazel` calls to close the gap.

### Motivation

#1894 traded speed for correctness: forcing every nested test to run one at a time removed the shared-lock timeout risk (#1884, #1885), at a disclosed cost on the critical path (+8 min on the steps that run them). This restores concurrency without reintroducing full lock contention.

The `local` -> `no-sandbox` switch matters beyond lanes: #1932 adds remote cache flags to `test_rules_scala.sh`'s bazel invocations, but a `local`-tagged test stays uncached regardless of the outer invocation's flags. Stacked together, the two PRs measured a 66% drop on Linux and roughly 50% on macOS/Windows for that CI step (numbers in #1932).

### Alternatives considered

Parallel output bases at K=4 were probed before (#1890/#1891) and rejected for disk cost (~1.7GB per lane) and a shared `--disk_cache` across lanes. This reuses the same idea at K=3; lanes here only share `--repository_cache` (external-repo downloads), already shared regardless of lane count, so the added disk cost is 2 extra ~1.7GB output bases, while `--disk_cache` contention stays exactly what it already was.

Capping the macOS lane lock at 1 too, matching Linux/Windows, was tried: it removes the same-lane race outright, at the cost of the bazel#18153 stall on unrelated tests. Kept the higher macOS capacity plus the script-level lock instead -- same safety, without that throughput cost.

### Test plan

- `bazel test -- //test/strict_dependency/... //test/missing_direct_deps/...`: 22/22 pass, including the 7 targets that take the new lock (`--clean-before-build` callers).
- Verified the lock itself outside Bazel: two concurrent shell processes on the same lane, one holding the lock for a few seconds -- the second waited the whole time and acquired it right after release. A process that exits mid-lock (simulated `exit 1`) still releases it, via the `EXIT` trap in `nested_bazel_setup`.
- Full local suite (`bazel test -- //... -//test_expect_failure/...`): 344/346 pass, 2 skipped.
