### PR TITLE
ci: remove xmllint/libxml2 installs left dead by the test_misc.sh migration

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -172,7 +172,6 @@ tasks:
       MSYS2_ARG_CONV_EXCL: "*"
     batch_commands:
       - "set PATH=/usr/bin;%PATH%" #Make sure bash uses msys commands over windows commands. (i.e. find).
-      - 'bash -lc "pacman --noconfirm --needed -S libxml2"' #tests require xmllint
       - "bash ./test_dependency_versions.sh" # script removes ./ from BASH_SOURCE
   bcr_presubmit:
     # Keep in sync with .bcr/presubmit.yml.

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -56,16 +56,12 @@ tasks:
     name: "./test_rules_scala"
     platform: ubuntu2004
     shell_commands:
-      # Install xmllint
-      - sudo apt update && sudo apt install --reinstall libxml2-utils -y
       - "./test_rules_scala.sh"
   test_rules_scala_linux_last_green:
     name: "./test_rules_scala (last_green Bazel)"
     platform: ubuntu2004
     bazel: last_green
     shell_commands:
-      # Install xmllint
-      - sudo apt update && sudo apt install --reinstall libxml2-utils -y
       - echo "common --lockfile_mode=update" >>.bazelrc
       # The nested-Bazel tests (expect_build_failure_test etc.) shell out to
       # `bazel` from inside a test action. bazelisk prepends the dir holding the
@@ -94,7 +90,6 @@ tasks:
       MSYS2_ARG_CONV_EXCL: "*"
     batch_commands:
       - "set PATH=/usr/bin;%PATH%" #Make sure bash uses msys commands over windows commands. (i.e. find).
-      - 'bash -lc "pacman --noconfirm --needed -S libxml2"' #tests require xmllint
       - "bash test_rules_scala.sh"
   test_coverage_linux:
     name: "./test_coverage"
@@ -150,7 +145,6 @@ tasks:
     name: "./test_rules_scala with jdk21"
     platform: ubuntu2004
     shell_commands:
-      - sudo apt update && sudo apt install -y libxml2-utils
       - echo "build --java_language_version=21" >> .bazelrc
       - echo "build --java_runtime_version=21" >> .bazelrc
       - echo "build --tool_java_language_version=21" >> .bazelrc


### PR DESCRIPTION
### Description

Stacked on #1946, which deletes `xmllint_test` from `test/shell/test_misc.sh`. That test was the only thing in `test_rules_scala.sh` that used `xmllint`, so the 4 CI steps installing `libxml2-utils`/`libxml2` for it (`test_rules_scala_linux`, `test_rules_scala_linux_last_green`, `test_rules_scala_win`, `test_rules_scala_jdk21`) are now dead weight, installing a package nothing uses.

Split into its own PR since it edits `.bazelci/presubmit.yml`, which Buildkite gates behind a manual maintainer unblock before running -- keeping it out of #1946 lets that PR's CI run without waiting on the gate.

`dependency_versions_windows` also installed `libxml2`, with the same "tests require xmllint" comment. That install predates this migration and was already stale on its own -- `test_dependency_versions.sh` has always been independent of `test_rules_scala.sh` and `xmllint`. Included here too, since it's the same category of dead xmllint setup.

### Motivation

Release impact: CI config only.
