### PR TITLE
fix: Run only a smoke subset of jssrc2cpg's own test suite in joern_test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -310,6 +310,7 @@ downstream_consumers = use_extension(
 downstream_consumers.consumer(
     name = "joern",
     commit = "7da091d0a6a860a89d411ee04e3a7e696dbdf6b1",
+    patches = ["//test/community_build:joern_jssrc2cpg_smoke.patch"],
     remote = "https://github.com/joernio/joern.git",
 )
 downstream_consumers.consumer(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -148,7 +148,7 @@
     "//test/community_build:downstream_repository.bzl%downstream_consumers": {
       "general": {
         "bzlTransitiveDigest": "iNbmMqJdb8MiDSGAH41GC2emXRrNu1I+eGxIIxnLxZo=",
-        "usagesDigest": "ylTxWZOsS2rL1viJm4oKFPgAglCgWPpVd5YJ+CTGZTU=",
+        "usagesDigest": "CwUUnc8bB6arWZ4SSw8Cx/ZV385dh8SV4CyMUYJ42MQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -159,7 +159,9 @@
             "attributes": {
               "remote": "https://github.com/joernio/joern.git",
               "commit": "7da091d0a6a860a89d411ee04e3a7e696dbdf6b1",
-              "patches": []
+              "patches": [
+                "@@//test/community_build:joern_jssrc2cpg_smoke.patch"
+              ]
             }
           },
           "dicer": {

--- a/test/community_build/BUILD
+++ b/test/community_build/BUILD
@@ -5,7 +5,11 @@
 load(":downstream_test.bzl", "downstream_test")
 load(":source_fingerprint.bzl", "exposed_top_level_dirs_test")
 
-exports_files(["downstream_test_driver.sh", "dicer_protobuf_version.patch"])
+exports_files([
+    "downstream_test_driver.sh",
+    "dicer_protobuf_version.patch",
+    "joern_jssrc2cpg_smoke.patch",
+])
 
 exposed_top_level_dirs_test(name = "exposed_top_level_dirs_test")
 
@@ -28,19 +32,37 @@ exposed_top_level_dirs_test(name = "exposed_top_level_dirs_test")
 #
 # extra_bazel_flags's --test_timeout bounds each nested test, not size
 # (which bounds this whole sh_test action).
+#
+# test_filter selects jssrc2cpg's own SmokeSuite (see
+# joern_jssrc2cpg_smoke.patch): jssrc2cpg is this test's single most
+# expensive target (~750-820s of the ~1050-1200s this whole test costs once
+# the nested build itself is warm), and its ~11k lines of test sources are
+# ~99% Joern's own JS/TS semantic correctness -- an assertion about Joern's
+# own correctness. The patch adds one new
+# file aggregating a handful of existing test classes (AST, CFG, dataflow,
+# type-recovery, plus the closest things to an integration smoke test: a
+# real AstGenRunner file-parse and a JVM HTTP server + full classpath) into
+# one suite; test_filter selects just that suite, so jssrc2cpg's test
+# sources still compile in full (real Scala 3 compile workload against the
+# toolchain under test) but only the smoke subset executes: measured
+# 748-820s -> 165s.
 downstream_test(
     name = "joern_test",
+    size = "enormous",
+    extra_bazel_flags = "--test_timeout=60,1800,1800,3600",
+    filtered_targets = ["//joern-cli/frontends/jssrc2cpg:tests"],
+    patches = ["//test/community_build:joern_jssrc2cpg_smoke.patch"],
     repo_name = "joern",
     scala_version = "3.7.4",
-    extra_bazel_flags = "--test_timeout=60,1800,1800,3600",
-    size = "enormous",
     target_compatible_with = ["@platforms//os:linux"],
     targets = [
         "//...",
         "-//joern-cli/frontends/php2cpg/...",
         "-//joern-cli/frontends/rust2cpg/...",
         "-//joern-cli/frontends/swiftsrc2cpg/...",
+        "-//joern-cli/frontends/jssrc2cpg/...",
     ],
+    test_filter = "io.joern.jssrc2cpg.SmokeSuite",
 )
 
 # dicer covers rules_scala's scala_proto/ScalaPB (gRPC) codegen path and
@@ -60,9 +82,10 @@ downstream_test(
 # "large" (900s) default in total.
 downstream_test(
     name = "dicer_test",
+    size = "enormous",
+    patches = ["//test/community_build:dicer_protobuf_version.patch"],
     repo_name = "dicer",
     scala_version = "2.12.21",
-    size = "enormous",
     target_compatible_with = ["@platforms//os:linux"],
     targets = [
         "//...",

--- a/test/community_build/BUILD
+++ b/test/community_build/BUILD
@@ -45,7 +45,7 @@ exposed_top_level_dirs_test(name = "exposed_top_level_dirs_test")
 # one suite; test_filter selects just that suite, so jssrc2cpg's test
 # sources still compile in full (real Scala 3 compile workload against the
 # toolchain under test) but only the smoke subset executes: measured
-# 748-820s -> 165s.
+# 748-820s -> 165-215s.
 downstream_test(
     name = "joern_test",
     size = "enormous",

--- a/test/community_build/downstream_test.bzl
+++ b/test/community_build/downstream_test.bzl
@@ -92,6 +92,9 @@ def downstream_test(
             regression.
         **kwargs: forwarded to the underlying `sh_test`.
     """
+    if bool(filtered_targets) != bool(test_filter):
+        fail("downstream_test '%s': filtered_targets and test_filter must both be set, or both left empty" % name)
+
     sh_test(
         name = name,
         srcs = ["//test/community_build:downstream_test_driver.sh"],

--- a/test/community_build/downstream_test.bzl
+++ b/test/community_build/downstream_test.bzl
@@ -95,21 +95,26 @@ def downstream_test(
     if bool(filtered_targets) != bool(test_filter):
         fail("downstream_test '%s': filtered_targets and test_filter must both be set, or both left empty" % name)
 
+    args = [
+        "--marker-rootpath",
+        "$(rootpath @{}//_bazel_native_marker:marker.txt)".format(repo_name),
+        "--scala-version",
+        scala_version,
+        "--output-base-name",
+        name,
+    ]
+    if extra_bazel_flags:
+        args += ["--extra-bazel-flags", extra_bazel_flags]
+    if test_filter:
+        args += ["--test-filter", test_filter]
+    if filtered_targets:
+        args += ["--filtered-targets"] + filtered_targets
+    args += ["--"] + targets
+
     sh_test(
         name = name,
         srcs = ["//test/community_build:downstream_test_driver.sh"],
-        args = [
-                   "--marker-rootpath",
-                   "$(rootpath @{}//_bazel_native_marker:marker.txt)".format(repo_name),
-                   "--scala-version",
-                   scala_version,
-                   "--output-base-name",
-                   name,
-               ] + (["--extra-bazel-flags", extra_bazel_flags] if extra_bazel_flags else []) +
-               (["--test-filter", test_filter] if test_filter else []) +
-               (["--filtered-targets"] + filtered_targets if filtered_targets else []) + [
-            "--",
-        ] + targets,
+        args = args,
         data = [
             "@{}//_bazel_native_marker:marker.txt".format(repo_name),
             "//test/expect_build_failure:nested_bazel.sh",

--- a/test/community_build/downstream_test.bzl
+++ b/test/community_build/downstream_test.bzl
@@ -31,6 +31,9 @@ def downstream_test(
         scala_version,
         targets,
         extra_bazel_flags = "",
+        filtered_targets = [],
+        test_filter = "",
+        patches = [],
         size = "large",
         tags = ["no-sandbox", "no-remote-exec", "requires-network", "no-last-green"],
         **kwargs):
@@ -41,8 +44,39 @@ def downstream_test(
         repo_name: name of the `downstream_consumer_repository` to test.
         scala_version: value to force via --repo_env=SCALA_VERSION (must be
             one this checkout's third_party repos carry).
-        targets: list of Bazel target patterns to test in the consumer repo.
+        targets: list of Bazel target patterns to test in the consumer repo,
+            run unfiltered in one nested `bazel test` invocation.
         extra_bazel_flags: extra flags forwarded to the nested `bazel test`.
+        filtered_targets: target patterns run only through a chosen
+            ScalaTest suite (`test_filter`), instead of their whole test
+            source tree -- e.g. joern_test uses this to run just a smoke
+            suite for jssrc2cpg, its most expensive target, while every
+            other target in `targets` keeps running unfiltered. Needs a
+            *second*, separate nested `bazel test` invocation, with
+            `extra_bazel_flags` plus `--test_filter=<test_filter>`: Bazel
+            applies `--test_filter` uniformly across every target in one
+            `bazel test` invocation, so sharing the main invocation would
+            apply that same suite name to every other target too, and each
+            one fails with "class not found" since the suite exists only in
+            the filtered target's classpath. Exclude a filtered target from
+            `targets` too (e.g. a `-//pkg/...` negative pattern), so it runs
+            exactly once.
+        test_filter: value forwarded as `filtered_targets`' nested `bazel
+            test`'s own `--test_filter`. A separate arg from
+            `extra_bazel_flags`, which stays a single `args` list element:
+            rules_shell's `sh_test` re-splits that element on whitespace
+            before the driver script's own `--extra-bazel-flags` parsing
+            sees it, so a value like `"--test_timeout=... --test_filter=..."`
+            hands the driver's arg loop a bare `--test_filter=...`, which
+            only its catch-all `*)` case matches, exiting with "Unknown
+            argument".
+        patches: patch files applied to `repo_name`'s consumer in
+            `MODULE.bazel` (that `consumer(...)` call's own `patches` attr).
+            Declared here too, as `data`, purely for this `sh_test`'s own
+            cache soundness: `source_fingerprint.bzl`'s scope stops at what
+            rules_scala exposes, leaving a patch under `test/` outside it,
+            so the patch content needs its own declared input to force a
+            real re-run instead of reusing a stale cached PASS.
         size: test size; defaults to "large" (nested Bazel invocation, cold
             Maven/git fetch on first run).
         tags: test tags; defaults to
@@ -62,20 +96,22 @@ def downstream_test(
         name = name,
         srcs = ["//test/community_build:downstream_test_driver.sh"],
         args = [
-            "--marker-rootpath",
-            "$(rootpath @{}//_bazel_native_marker:marker.txt)".format(repo_name),
-            "--scala-version",
-            scala_version,
-            "--output-base-name",
-            name,
-        ] + (["--extra-bazel-flags", extra_bazel_flags] if extra_bazel_flags else []) + [
+                   "--marker-rootpath",
+                   "$(rootpath @{}//_bazel_native_marker:marker.txt)".format(repo_name),
+                   "--scala-version",
+                   scala_version,
+                   "--output-base-name",
+                   name,
+               ] + (["--extra-bazel-flags", extra_bazel_flags] if extra_bazel_flags else []) +
+               (["--test-filter", test_filter] if test_filter else []) +
+               (["--filtered-targets"] + filtered_targets if filtered_targets else []) + [
             "--",
         ] + targets,
         data = [
             "@{}//_bazel_native_marker:marker.txt".format(repo_name),
             "//test/expect_build_failure:nested_bazel.sh",
             "@rules_scala_source_fingerprint//:fingerprint.txt",
-        ],
+        ] + patches,
         size = size,
         tags = tags,
         **kwargs

--- a/test/community_build/downstream_test_driver.sh
+++ b/test/community_build/downstream_test_driver.sh
@@ -6,7 +6,8 @@
 # repository rule already wrote into the consumer's MODULE.bazel.
 #
 # Usage: downstream_test_driver.sh --marker-rootpath <path> --scala-version <v> \
-#   --output-base-name <name> [--extra-bazel-flags <flags>] -- <target-pattern>...
+#   --output-base-name <name> [--extra-bazel-flags <flags>] [--test-filter <value>] \
+#   -- <target-pattern>...
 #
 # Named flags because Bazel/rules_shell silently drops or mangles blank
 # `args` entries -- same convention as test/expect_build_failure/expect_build_failure.sh.
@@ -17,6 +18,8 @@ marker_rootpath=""
 scala_version=""
 output_base_name=""
 extra_bazel_flags=""
+test_filter=""
+filtered_targets=()
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --marker-rootpath)
@@ -34,6 +37,17 @@ while [[ "$#" -gt 0 ]]; do
     --extra-bazel-flags)
       extra_bazel_flags="$2"
       shift 2
+      ;;
+    --test-filter)
+      test_filter="$2"
+      shift 2
+      ;;
+    --filtered-targets)
+      shift
+      while [[ "$#" -gt 0 && "$1" != "--" ]]; do
+        filtered_targets+=("$1")
+        shift
+      done
       ;;
     --)
       shift
@@ -237,8 +251,28 @@ done
 # gives at the outer level by forcing a real re-run instead of serving a
 # stale PASS. The cost of a retry-attempt rerun scales with that count.
 #
+# Captured rather than let `set -e` exit here: both invocations always run
+# regardless of the first's outcome, and the combined exit status (see
+# below) reflects either one failing.
+status=0
 # shellcheck disable=SC2086 # intentional word-splitting: extra_bazel_flags
 # and targets are each meant to expand to multiple words/patterns.
 nested_bazel_run test --test_output=errors --cache_test_results=no \
   --repo_env=SCALA_VERSION="${scala_version}" \
-  ${extra_bazel_flags} -- "${targets[@]}"
+  ${extra_bazel_flags} -- "${targets[@]}" || status="$?"
+
+# A second, separate invocation: --test_filter applies to every target in a
+# `bazel test` command line, so filtered_targets (a ScalaTest suite name
+# that exists in only one target's classpath) needs its own invocation to
+# keep from failing every other target sharing it with "class not found".
+# Carries the same extra_bazel_flags as the first invocation (e.g. the
+# --test_timeout every target here needs).
+if [[ "${#filtered_targets[@]}" -gt 0 ]]; then
+  # shellcheck disable=SC2086 # same intentional word-splitting as above.
+  nested_bazel_run test --test_output=errors --cache_test_results=no \
+    --repo_env=SCALA_VERSION="${scala_version}" \
+    ${extra_bazel_flags} --test_filter="${test_filter}" \
+    -- "${filtered_targets[@]}" || status="$?"
+fi
+
+exit "${status}"

--- a/test/community_build/downstream_test_driver.sh
+++ b/test/community_build/downstream_test_driver.sh
@@ -268,11 +268,15 @@ nested_bazel_run test --test_output=errors --cache_test_results=no \
 # Carries the same extra_bazel_flags as the first invocation (e.g. the
 # --test_timeout every target here needs).
 if [[ "${#filtered_targets[@]}" -gt 0 ]]; then
+  filtered_status=0
   # shellcheck disable=SC2086 # same intentional word-splitting as above.
   nested_bazel_run test --test_output=errors --cache_test_results=no \
     --repo_env=SCALA_VERSION="${scala_version}" \
     ${extra_bazel_flags} --test_filter="${test_filter}" \
-    -- "${filtered_targets[@]}" || status="$?"
+    -- "${filtered_targets[@]}" || filtered_status="$?"
+  if [[ "${filtered_status}" -gt "${status}" ]]; then
+    status="${filtered_status}"
+  fi
 fi
 
 exit "${status}"

--- a/test/community_build/downstream_test_driver.sh
+++ b/test/community_build/downstream_test_driver.sh
@@ -7,7 +7,7 @@
 #
 # Usage: downstream_test_driver.sh --marker-rootpath <path> --scala-version <v> \
 #   --output-base-name <name> [--extra-bazel-flags <flags>] [--test-filter <value>] \
-#   -- <target-pattern>...
+#   [--filtered-targets <target>...] -- <target-pattern>...
 #
 # Named flags because Bazel/rules_shell silently drops or mangles blank
 # `args` entries -- same convention as test/expect_build_failure/expect_build_failure.sh.

--- a/test/community_build/downstream_test_driver.sh
+++ b/test/community_build/downstream_test_driver.sh
@@ -254,6 +254,11 @@ done
 # Captured rather than let `set -e` exit here: both invocations always run
 # regardless of the first's outcome, and the combined exit status (see
 # below) reflects either one failing.
+#
+# The unfiltered `targets` list is expected to already exclude any
+# filtered_targets (via the caller's own negative pattern in BUILD -- see
+# downstream_test.bzl's filtered_targets docstring), so a filtered target
+# runs exactly once, through the second invocation below.
 status=0
 # shellcheck disable=SC2086 # intentional word-splitting: extra_bazel_flags
 # and targets are each meant to expand to multiple words/patterns.

--- a/test/community_build/joern_jssrc2cpg_smoke.patch
+++ b/test/community_build/joern_jssrc2cpg_smoke.patch
@@ -17,7 +17,7 @@
 # flag applies to every target in one invocation), so jssrc2cpg's own ~11k
 # lines of test sources still compile in full (real Scala 3 compile
 # workload against the toolchain under test), but only this smoke subset
-# executes: measured 748-820s -> 165s.
+# executes: measured 748-820s -> 165-215s.
 --- /dev/null
 +++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/SmokeSuite.scala
 @@ -0,0 +1,18 @@

--- a/test/community_build/joern_jssrc2cpg_smoke.patch
+++ b/test/community_build/joern_jssrc2cpg_smoke.patch
@@ -1,0 +1,41 @@
+# jssrc2cpg's own test suite is ~99% Joern's JS/TS semantic correctness (AST
+# node shapes, CFG edges, dataflow paths for hundreds of language-construct
+# variations) -- signal about Joern's own correctness. It's also this
+# downstream_test's single most expensive target: ~750-820s of the
+# ~1050-1200s the whole joern_test costs, once the nested build itself is
+# warm (see downstream_test.bzl's "Cacheability" docstring for that other
+# half).
+#
+# This adds one new file, keeping Joern's existing test files exactly as
+# upstream ships them, aggregating a handful of existing test classes
+# (spanning AST, CFG, dataflow, and type-recovery passes, plus the two
+# closest things to an integration smoke test: ProjectParseTests's real
+# AstGenRunner/file I/O and JsSrc2CpgHTTPServerTests's JVM HTTP server + full
+# classpath) into one ScalaTest suite. `downstream_test.bzl`'s
+# `test_filter`/`filtered_targets` for joern_test select just this one suite
+# via `--test_filter` (in its own nested `bazel test` invocation, since that
+# flag applies to every target in one invocation), so jssrc2cpg's own ~11k
+# lines of test sources still compile in full (real Scala 3 compile
+# workload against the toolchain under test), but only this smoke subset
+# executes: measured 748-820s -> 165s.
+--- /dev/null
++++ b/joern-cli/frontends/jssrc2cpg/src/test/scala/io/joern/jssrc2cpg/SmokeSuite.scala
+@@ -0,0 +1,18 @@
++package io.joern.jssrc2cpg
++
++import _root_.io.joern.jssrc2cpg.dataflow.DataflowTests
++import _root_.io.joern.jssrc2cpg.io.{JsSrc2CpgHTTPServerTests, ProjectParseTests}
++import _root_.io.joern.jssrc2cpg.passes.TypeRecoveryPassTests
++import _root_.io.joern.jssrc2cpg.passes.ast.SimpleAstCreationPassTests
++import _root_.io.joern.jssrc2cpg.passes.cfg.SimpleCfgCreationPassTests
++import org.scalatest.Suites
++
++class SmokeSuite
++    extends Suites(
++      new SimpleAstCreationPassTests,
++      new SimpleCfgCreationPassTests,
++      new DataflowTests,
++      new TypeRecoveryPassTests,
++      new ProjectParseTests,
++      new JsSrc2CpgHTTPServerTests
++    )


### PR DESCRIPTION
### Description

`joern_test`'s `jssrc2cpg` target is its single most expensive one: ~750-820s of the ~1050-1200s the whole test costs once the nested build is warm. Its ~11k lines of test sources are close to entirely Joern's own JS/TS semantic correctness (AST node shapes, CFG edges, dataflow paths, type recovery for hundreds of language-construct variations) -- an assertion about Joern's own correctness.

This adds one new file to Joern's checkout via a patch (`joern_jssrc2cpg_smoke.patch`, same mechanism as the existing `dicer_protobuf_version.patch`), keeping every one of Joern's own test files exactly as upstream ships them. The new file aggregates 6 existing test classes into one ScalaTest suite: representative AST/CFG/dataflow/type-recovery passes, plus the two closest things jssrc2cpg has to an integration smoke test (`ProjectParseTests`'s real `AstGenRunner`/file I/O, and `JsSrc2CpgHTTPServerTests`'s JVM HTTP server + full classpath).

`downstream_test.bzl` gets three new params:
- `filtered_targets` + `test_filter`: a target list run in a *second*, separate nested `bazel test` invocation with `--test_filter` set. Bazel's `--test_filter` applies uniformly across every target in one `bazel test` command line, so a ScalaTest suite name that exists only in jssrc2cpg's classpath needs its own invocation -- sharing the main one would fail every other target in it with "class not found". `downstream_test_driver.sh` now runs both invocations unconditionally (captures the first's exit status instead of letting `set -e` skip the second on a failure) and exits with the worse of the two.
- `patches`: declares the patch file as `data` on the `sh_test`, so an edit to the patch itself is a declared input that forces a real re-run -- `source_fingerprint.bzl`'s scope stops at what rules_scala exposes, leaving a patch under `test/` outside it. Applied here to both `joern_jssrc2cpg_smoke.patch` and the pre-existing `dicer_protobuf_version.patch`, which had the same gap.

jssrc2cpg's test sources still compile in full either way (real Scala 3 compile workload against the toolchain under test) -- only the smoke subset actually executes.

### Motivation

Measured on Linux, this test's own platform: jssrc2cpg 748-820s -> 165-215s. Combined with #1953's build-action cache, a rough estimate for the whole `joern_test` step: ~1026-1200s -> ~250-400s.

This saving also compounds inside `./test_rules_scala.sh`: `test/...` matches `joern_test`, and that script runs `bazel test .../test/...` under several different `--extra_toolchains`, each one discarding Bazel's analysis cache (confirmed directly: `WARNING: Build option --extra_toolchains has changed, discarding analysis cache`) and re-running `joern_test` in full. This cost lands up to 4 times per `./test_rules_scala.sh` run, on a step that is on the real CI critical path.

### Trade-off

`downstream_test` only cares about the toolchain signal here. There's a small chance this cuts something useful -- going ahead anyway.