### PR TITLE
fix: Bump disappearing_class_test to size=large to fix macOS CI timeout

### DIFF
--- a/test/disappearing_class/BUILD
+++ b/test/disappearing_class/BUILD
@@ -14,6 +14,7 @@ scala_library(
 
 sh_test(
     name = "disappearing_class_test",
+    size = "large",
     srcs = ["disappearing_class_test.sh"],
     args = [
         "//test/disappearing_class:uses_class",


### PR DESCRIPTION
### Description

Bumps `test/disappearing_class:disappearing_class_test`'s size to `large` (900s). It was the only test using `nested_bazel.sh` still on the "medium" (300s) default -- every other such test already uses `large`, including ones running just one nested build (this one runs two).

### Motivation

This test times out on macOS CI often, and even its passing runs regularly land within seconds of the 300s cap. No change in its own cost over time -- it's variance from runner load, not a regression.