### PR TITLE
test: Drop exclusive tag from nested-bazel tests with unique output bases

### DIFF
--- a/test/argument_file_in_runner/BUILD
+++ b/test/argument_file_in_runner/BUILD
@@ -13,7 +13,6 @@ sh_test(
         "//test/src/main/scala/scalarules/test/large_classpath:largeClasspath",
     ],
     tags = [
-        "exclusive",
         # The nested build also reads the use_argument_file_in_runner toolchain
         # straight from the real workspace, which isn't practical to declare as
         # a source input, so caching is disabled to avoid serving a stale pass

--- a/test/custom_reporter/BUILD
+++ b/test/custom_reporter/BUILD
@@ -22,7 +22,6 @@ sh_test(
         "//test/scala_test:custom_reporter",
     ],
     tags = [
-        "exclusive",
         "local",
         "requires-network",
     ],

--- a/test/scala_junit_test/BUILD
+++ b/test/scala_junit_test/BUILD
@@ -236,7 +236,6 @@ sh_test(
         "//test/expect_build_failure:nested_bazel.sh",
     ],
     tags = [
-        "exclusive",
         "local",
         "requires-network",
     ],
@@ -255,7 +254,6 @@ sh_test(
         "//test/expect_build_failure:nested_bazel.sh",
     ],
     tags = [
-        "exclusive",
         "local",
         "requires-network",
     ],
@@ -372,7 +370,6 @@ sh_test(
         "//test/expect_build_failure:nested_bazel.sh",
     ],
     tags = [
-        "exclusive",
         "local",
         "requires-network",
     ],

--- a/test/scala_proto_library_action_label/BUILD
+++ b/test/scala_proto_library_action_label/BUILD
@@ -15,7 +15,6 @@ sh_test(
         "//test/expect_build_failure:nested_bazel.sh",
     ],
     tags = [
-        "exclusive",
         "external",
         "local",
         "requires-network",

--- a/test/toolchain_macros_repo_mapping/BUILD
+++ b/test/toolchain_macros_repo_mapping/BUILD
@@ -15,7 +15,6 @@ sh_test(
         "//testing:testing.bzl",
     ],
     tags = [
-        "exclusive",
         "local",
         "requires-network",
     ],


### PR DESCRIPTION
### Description

Audits every `sh_test` that drives a nested `bazel` invocation via `nested_bazel.sh` directly (not through the `_nested_bazel_test` macros already handled in #1939), and drops `exclusive` from the ones whose nested output base isn't shared with any other test: `scala_proto_library_action_label`, `toolchain_macros_repo_mapping`, `argument_file_in_runner`, `custom_reporter`, and the 3 xml-report tests in `scala_junit_test`.

Kept `exclusive` where the nested output base is actually shared across multiple targets: `scala_config`, `compiler_sources_integrity_test`, `semanticdb`, `fetch_sources`, and `test/.../ijar` plus `strict_deps/no_recompilation` (which also edit real source files in place, so they'd race on top of sharing the base). Also kept it on `build_event_protocol` and `diagnostics_reporter`: their `sh_test` targets are generated in a loop and all share one output base name by design, to avoid duplicating the extracted Scala jars per target.

### Motivation

`exclusive` forces a test to run alone, serialized against the rest of the suite -- a real cost when the test doesn't actually share any state with others. Each of the 7 targets here uses its own nested output base and touches no shared filesystem path outside it, so nothing else can race with them.
