### PR TITLE
ci: Add remote-cache flags to test_rules_scala.sh's extra-toolchains runs

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -56,7 +56,7 @@ tasks:
     name: "./test_rules_scala"
     platform: ubuntu2004
     shell_commands:
-      - "RULES_SCALA_REMOTE_CACHE=ubuntu2004 ./test_rules_scala.sh"
+      - "RULES_SCALA_REMOTE_CACHE=1 ./test_rules_scala.sh"
   test_rules_scala_linux_last_green:
     name: "./test_rules_scala (last_green Bazel)"
     platform: ubuntu2004
@@ -81,7 +81,7 @@ tasks:
     name: "./test_rules_scala"
     platform: macos
     shell_commands:
-      - "RULES_SCALA_REMOTE_CACHE=macos ./test_rules_scala.sh"
+      - "RULES_SCALA_REMOTE_CACHE=1 ./test_rules_scala.sh"
   test_rules_scala_win:
     name: "./test_rules_scala"
     platform: windows

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -56,7 +56,7 @@ tasks:
     name: "./test_rules_scala"
     platform: ubuntu2004
     shell_commands:
-      - "./test_rules_scala.sh"
+      - "RULES_SCALA_REMOTE_CACHE=ubuntu2004 ./test_rules_scala.sh"
   test_rules_scala_linux_last_green:
     name: "./test_rules_scala (last_green Bazel)"
     platform: ubuntu2004
@@ -81,7 +81,7 @@ tasks:
     name: "./test_rules_scala"
     platform: macos
     shell_commands:
-      - "./test_rules_scala.sh"
+      - "RULES_SCALA_REMOTE_CACHE=macos ./test_rules_scala.sh"
   test_rules_scala_win:
     name: "./test_rules_scala"
     platform: windows

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -33,17 +33,63 @@ fi
 toolchain_sweep_build_flag="--build_tag_filters=-skip-toolchain-sweep"
 toolchain_sweep_test_flag="--test_tag_filters=${base_test_tag_filters:+${base_test_tag_filters},}-skip-toolchain-sweep"
 
+# The --extra_toolchains lines below each build/test a toolchain config that no
+# other CI task exercises, so there's nothing else for Bazel to reuse -- but
+# unlike a build_targets/test_targets task, a shell_commands task like this one
+# (bazelci.py's execute_shell_commands()) gets no remote-cache flags for free.
+# Add them ourselves, gated by RULES_SCALA_REMOTE_CACHE=<platform>, so repeated
+# CI runs of this script reuse each other's cache instead of always starting
+# from empty.
+remote_cache_flags=()
+if [[ -n "${RULES_SCALA_REMOTE_CACHE:-}" ]]; then
+  buildkite_org="${BUILDKITE_ORGANIZATION_SLUG:-bazel}"
+  cloud_project=bazel-untrusted
+  bucket_id=untrusted
+  if [[ "$buildkite_org" == bazel-trusted ]]; then
+    cloud_project=bazel-public
+    bucket_id=trusted
+  fi
+  sha256() { if command -v sha256sum >/dev/null; then sha256sum; else shasum -a 256; fi; }
+  # A tag we own, not bazelci.py's "cache-poisoning-<date>" one: this cache is
+  # only ever read/written by this script's own runs, so there's no upstream
+  # tag to track or fall out of sync with.
+  silo_key=$(printf '%s:test_rules_scala.sh-extra-toolchains-v1:%s:' \
+    "$buildkite_org" "$RULES_SCALA_REMOTE_CACHE" | sha256 | cut -d' ' -f1)
+  if [[ "$RULES_SCALA_REMOTE_CACHE" == macos ]]; then
+    remote_cache_flags=(
+      "--remote_cache=https://storage.googleapis.com/bazel-${bucket_id}-build-cache"
+      "--google_default_credentials"
+      "--remote_timeout=3600"
+    )
+  else
+    remote_cache_flags=(
+      "--remote_cache=remotebuildexecution.googleapis.com"
+      "--remote_instance_name=projects/${cloud_project}/instances/default_instance"
+      "--google_default_credentials"
+      "--bes_backend=buildeventservice.googleapis.com"
+      "--bes_results_url=https://btx.cloud.google.com/invocations/"
+      "--bes_timeout=360s"
+      "--bes_instance_name=${cloud_project}"
+      "--remote_timeout=60"
+    )
+  fi
+  remote_cache_flags+=(
+    "--remote_max_connections=200"
+    "--remote_default_exec_properties=cache-silo-key=${silo_key}"
+  )
+fi
+
 $runner bazel build src/... test/...
 #$runner bazel build src/... test/... --all_incompatible_changes
 $runner bazel test "${test_flags[@]}" src/... test/...
 $runner bazel test "${test_flags[@]}" third_party/...
-$runner bazel build "${toolchain_sweep_build_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel build "${toolchain_sweep_build_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel build "${toolchain_sweep_build_flag}" "${remote_cache_flags[@]}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel build "${toolchain_sweep_build_flag}" "${remote_cache_flags[@]}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
 #$runner bazel build --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error --all_incompatible_changes -- test/...
-$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
-$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
-$runner bazel build test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
-$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
+$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" "${remote_cache_flags[@]}" --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/...
+$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" "${remote_cache_flags[@]}" --extra_toolchains=//scala:minimal_direct_source_deps -- test/...
+$runner bazel build "${remote_cache_flags[@]}" test/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn
+$runner bazel test "${test_output_flag}" "${toolchain_sweep_test_flag}" "${remote_cache_flags[@]}" //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
 $runner bazel build //test/binary_in_genrule:ScalaBinaryInGenrule --nolegacy_external_runfiles
 $runner bazel build //test_statsfile:Simple_statsfile
-$runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
+$runner bazel build "${remote_cache_flags[@]}" //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -37,11 +37,11 @@ toolchain_sweep_test_flag="--test_tag_filters=${base_test_tag_filters:+${base_te
 # other CI task exercises, so there's nothing else for Bazel to reuse -- but
 # unlike a build_targets/test_targets task, a shell_commands task like this one
 # (bazelci.py's execute_shell_commands()) gets no remote-cache flags for free.
-# Add them ourselves, gated by RULES_SCALA_REMOTE_CACHE=<platform>, so repeated
-# CI runs of this script reuse each other's cache instead of always starting
-# from empty.
+# Add them here, gated by RULES_SCALA_REMOTE_CACHE=1, so repeated CI runs of
+# this script share a cache across runs.
 remote_cache_flags=()
 if [[ -n "${RULES_SCALA_REMOTE_CACHE:-}" ]]; then
+  platform=$(uname)
   buildkite_org="${BUILDKITE_ORGANIZATION_SLUG:-bazel}"
   cloud_project=bazel-untrusted
   bucket_id=untrusted
@@ -52,10 +52,15 @@ if [[ -n "${RULES_SCALA_REMOTE_CACHE:-}" ]]; then
   sha256() { if command -v sha256sum >/dev/null; then sha256sum; else shasum -a 256; fi; }
   # A tag we own, not bazelci.py's "cache-poisoning-<date>" one: this cache is
   # only ever read/written by this script's own runs, so there's no upstream
-  # tag to track or fall out of sync with.
-  silo_key=$(printf '%s:test_rules_scala.sh-extra-toolchains-v1:%s:' \
-    "$buildkite_org" "$RULES_SCALA_REMOTE_CACHE" | sha256 | cut -d' ' -f1)
-  if [[ "$RULES_SCALA_REMOTE_CACHE" == macos ]]; then
+  # tag to track or fall out of sync with. On macOS, fold in the OS/Xcode
+  # version too, so a runner-image upgrade gets a fresh silo instead of
+  # sharing one with results built under the old toolchain.
+  silo_key_input="${buildkite_org}:test_rules_scala.sh-extra-toolchains-v1:${platform}"
+  if [[ "$platform" == Darwin ]]; then
+    silo_key_input+=":$(sw_vers -productVersion):$(xcode-select -p):$(xcodebuild -version)"
+  fi
+  silo_key=$(printf '%s' "$silo_key_input" | sha256 | cut -d' ' -f1)
+  if [[ "$platform" == Darwin ]]; then
     remote_cache_flags=(
       "--remote_cache=https://storage.googleapis.com/bazel-${bucket_id}-build-cache"
       "--google_default_credentials"


### PR DESCRIPTION
### Description

The `--extra_toolchains` lines in `test_rules_scala.sh` run as a plain shell command in CI, so they never get the remote-cache flags that a normal build/test task gets automatically. This adds those flags by hand, gated by `RULES_SCALA_REMOTE_CACHE=1`, using the same setup bazelci.py uses for other tasks.

### Motivation

Right now that toolchain build starts from scratch on every single CI run: about 3600s on Linux, 6400s on macOS. Opened as draft so we can run CI twice in a row and check the second run actually reuses the cache before calling this ready.

Release impact: tests/CI only.