### PR TITLE
fix: Skip executing dicer's own business-logic tests in dicer_test

### DIFF
--- a/test/community_build/BUILD
+++ b/test/community_build/BUILD
@@ -81,12 +81,22 @@ downstream_test(
 # size = "enormous" for the same reason as joern_test above: dicer's nested
 # test suite is large enough, with some tests minutes-long, to exceed this
 # sh_test's own "large" (900s) default in total.
+#
+# smoke_test_targets: dicer's other ~150 test targets assert dicer's own
+# business logic; these two are the actual runtime check for
+# scala_proto/ScalaPB codegen, round-tripping real generated messages
+# (`toProto`/`fromProto`). gRPC service/stub code keeps compile-only
+# coverage, same as everything else in `targets`.
 downstream_test(
     name = "dicer_test",
     size = "enormous",
     patches = ["//test/community_build:dicer_protobuf_version.patch"],
     repo_name = "dicer",
     scala_version = "2.12.21",
+    smoke_test_targets = [
+        "//dicer/common:assignment_test",
+        "//dicer/common:diff_assignment_test",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
     targets = [
         "//...",

--- a/test/community_build/BUILD
+++ b/test/community_build/BUILD
@@ -68,12 +68,6 @@ downstream_test(
 # dicer_test's job: exercise rules_scala's scala_proto/ScalaPB (gRPC)
 # codegen and Scala 2.12 support.
 #
-# The 8 targets excluded below start a real etcd binary. That binary is
-# what repeatedly times out in CI.
-#
-# algorithm_chaos_test is excluded below: it asserts a randomly-seeded
-# statistical bound, flaky by construction.
-#
 # Linux-only: this repo's macOS CI hits a coursier network timeout running
 # dicer_test, and its Windows CI is missing %LocalAppData%, needed by the
 # nested Bazelisk invocation.
@@ -86,7 +80,12 @@ downstream_test(
 # business logic; these two are the actual runtime check for
 # scala_proto/ScalaPB codegen, round-tripping real generated messages
 # (`toProto`/`fromProto`). gRPC service/stub code keeps compile-only
-# coverage, same as everything else in `targets`.
+# coverage, same as everything else in `targets` -- which needs no
+# exclusions any more: a real etcd binary starting (8 targets across
+# //caching/util and //dicer/assigner, //dicer/common), a flaky statistical
+# assertion (algorithm_chaos_test), and a tight test timeout under load
+# (assignment_generator_test) were all test-execution problems, moot once
+# a target only builds.
 downstream_test(
     name = "dicer_test",
     size = "enormous",
@@ -98,20 +97,5 @@ downstream_test(
         "//dicer/common:diff_assignment_test",
     ],
     target_compatible_with = ["@platforms//os:linux"],
-    targets = [
-        "//...",
-        "-//caching/util:etcd_suite",
-        "-//dicer/assigner/algorithm:algorithm_chaos_test",
-        "-//dicer/assigner:assigner_main_test",
-        "-//dicer/assigner:etcd_preferred_assigner_driver_test",
-        "-//dicer/assigner:etcd_preferred_assigner_integration_test",
-        "-//dicer/assigner:etcd_preferred_assigner_store_test",
-        "-//dicer/assigner:multiple_assigner_instances_test",
-        "-//dicer/assigner:target_migration_integration_test",
-        "-//dicer/common:etcd_bootstrapper_test",
-        # Its own `timeout = "short"` (60s) leaves it running within a second
-        # of that limit even on an otherwise-idle machine, so any extra load
-        # sharing the host tips it into an occasional TIMEOUT.
-        "-//dicer/assigner:assignment_generator_test",
-    ],
+    targets = ["//..."],
 )

--- a/test/community_build/downstream_test.bzl
+++ b/test/community_build/downstream_test.bzl
@@ -33,6 +33,7 @@ def downstream_test(
         extra_bazel_flags = "",
         filtered_targets = [],
         test_filter = "",
+        smoke_test_targets = [],
         patches = [],
         size = "large",
         tags = ["no-sandbox", "no-remote-exec", "requires-network", "skip-last-green-bazel"],
@@ -45,8 +46,13 @@ def downstream_test(
         scala_version: value to force via --repo_env=SCALA_VERSION (must be
             one this checkout's third_party repos carry).
         targets: list of Bazel target patterns to test in the consumer repo,
-            run unfiltered in one nested `bazel test` invocation.
-        extra_bazel_flags: extra flags forwarded to the nested `bazel test`.
+            run unfiltered in one nested `bazel test` invocation -- or, when
+            `smoke_test_targets` is set, compiled in one nested `bazel build`
+            invocation instead (see `smoke_test_targets`).
+        extra_bazel_flags: extra flags forwarded to the nested `bazel test`
+            -- or, when `smoke_test_targets` is set, to *both* the main
+            `bazel build` and the separate `bazel test` for
+            `smoke_test_targets`.
         filtered_targets: target patterns run only through a chosen
             ScalaTest suite (`test_filter`), instead of their whole test
             source tree -- e.g. joern_test uses this to run just a smoke
@@ -70,6 +76,10 @@ def downstream_test(
             hands the driver's arg loop a bare `--test_filter=...`, which
             only its catch-all `*)` case matches, exiting with "Unknown
             argument".
+        smoke_test_targets: if set, only these targets get tested; every
+            other target in `targets` only builds (see
+            downstream_test_driver.sh for the mechanism). Pick one
+            mechanism per target: this, or `filtered_targets`.
         patches: patch files applied to `repo_name`'s consumer in
             `MODULE.bazel` (that `consumer(...)` call's own `patches` attr).
             Declared here too, as `data`, purely for this `sh_test`'s own
@@ -109,6 +119,8 @@ def downstream_test(
         args += ["--test-filter", test_filter]
     if filtered_targets:
         args += ["--filtered-targets"] + filtered_targets
+    if smoke_test_targets:
+        args += ["--smoke-test-targets"] + smoke_test_targets
     args += ["--"] + targets
 
     sh_test(

--- a/test/community_build/downstream_test_driver.sh
+++ b/test/community_build/downstream_test_driver.sh
@@ -7,7 +7,7 @@
 #
 # Usage: downstream_test_driver.sh --marker-rootpath <path> --scala-version <v> \
 #   --output-base-name <name> [--extra-bazel-flags <flags>] [--test-filter <value>] \
-#   [--filtered-targets <target>...] -- <target-pattern>...
+#   [--filtered-targets <target>...] [--smoke-test-targets <target>...] -- <target-pattern>...
 #
 # Named flags because Bazel/rules_shell silently drops or mangles blank
 # `args` entries -- same convention as test/expect_build_failure/expect_build_failure.sh.
@@ -20,6 +20,7 @@ output_base_name=""
 extra_bazel_flags=""
 test_filter=""
 filtered_targets=()
+smoke_test_targets=()
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --marker-rootpath)
@@ -44,8 +45,20 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --filtered-targets)
       shift
-      while [[ "$#" -gt 0 && "$1" != "--" ]]; do
+      # Stop at the next flag (anything starting with "--"), not just the
+      # bare "--" target-list separator: a following --smoke-test-targets
+      # would otherwise get swallowed into this list too. Safe because
+      # Bazel target patterns never start with "--" (a negative pattern
+      # like "-//pkg/..." starts with a single "-").
+      while [[ "$#" -gt 0 && "$1" != --* ]]; do
         filtered_targets+=("$1")
+        shift
+      done
+      ;;
+    --smoke-test-targets)
+      shift
+      while [[ "$#" -gt 0 && "$1" != --* ]]; do
+        smoke_test_targets+=("$1")
         shift
       done
       ;;
@@ -260,9 +273,18 @@ done
 # downstream_test.bzl's filtered_targets docstring), so a filtered target
 # runs exactly once, through the second invocation below.
 status=0
-# shellcheck disable=SC2086 # intentional word-splitting: extra_bazel_flags
-# and targets are each meant to expand to multiple words/patterns.
-nested_bazel_run test --test_output=errors --cache_test_results=no \
+# smoke_test_targets means `targets` only builds here (see
+# downstream_test.bzl's docstring), so this invocation drops the
+# test-only --test_output/--cache_test_results flags.
+main_command="test"
+main_command_extra_flags="--test_output=errors --cache_test_results=no"
+if [[ "${#smoke_test_targets[@]}" -gt 0 ]]; then
+  main_command="build"
+  main_command_extra_flags=""
+fi
+# shellcheck disable=SC2086 # intentional word-splitting: main_command_extra_flags,
+# extra_bazel_flags and targets are each meant to expand to multiple words/patterns.
+nested_bazel_run "${main_command}" ${main_command_extra_flags} \
   --repo_env=SCALA_VERSION="${scala_version}" \
   ${extra_bazel_flags} -- "${targets[@]}" || status="$?"
 
@@ -281,6 +303,22 @@ if [[ "${#filtered_targets[@]}" -gt 0 ]]; then
     -- "${filtered_targets[@]}" || filtered_status="$?"
   if [[ "${filtered_status}" -gt "${status}" ]]; then
     status="${filtered_status}"
+  fi
+fi
+
+# A third, separate invocation for smoke_test_targets: the main invocation
+# above only *built* them (part of `targets`), so they still need their own
+# `bazel test` to actually execute -- reusing, via Bazel's own action cache
+# (same output_base), the build outputs the main invocation already
+# produced.
+if [[ "${#smoke_test_targets[@]}" -gt 0 ]]; then
+  smoke_status=0
+  # shellcheck disable=SC2086 # same intentional word-splitting as above.
+  nested_bazel_run test --test_output=errors --cache_test_results=no \
+    --repo_env=SCALA_VERSION="${scala_version}" \
+    ${extra_bazel_flags} -- "${smoke_test_targets[@]}" || smoke_status="$?"
+  if [[ "${smoke_status}" -gt "${status}" ]]; then
+    status="${smoke_status}"
   fi
 fi
 


### PR DESCRIPTION
### Description

Adds a `smoke_test_targets` mechanism to `downstream_test`: the nested build still compiles everything in `targets`, but only the listed targets actually execute as tests. Applied to `dicer_test`: its other ~150 test targets assert dicer's own business logic, unrelated to what `dicer_test` checks (scala_proto/ScalaPB codegen, Scala 2.12 support). Two targets that round-trip real generated messages (`toProto`/`fromProto`) stay as the actual runtime check for that.

Also drops `dicer_test`'s 9 target exclusions (etcd-dependent targets, a flaky statistical test, a timeout-sensitive test): they mattered only for test execution, and the main invocation now only builds them.

### Motivation

`dicer_test`'s test-execution phase was spent almost entirely on tests unrelated to rules_scala's own correctness. Measured once locally: build + these two targets ~46.5s, vs ~64s to also run all ~150 -- roughly 18s removed from every run.
