### PR TITLE
[fix] Release job adjustments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
-      bazel_test_command: "bazel test //src/... //test/... //third_party/..."
+      bazel_test_command: "bazel test -- //... -//test/community_build/..."
       prerelease: false
       draft: true
       release_files: rules_scala-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
-      bazel_test_command: "bazel test -- //..."
+      bazel_test_command: "bazel test -- //... -//test/scalac_exec_group:scalac_action_exec_properties_test"
       prerelease: false
       draft: true
       release_files: rules_scala-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
-      bazel_test_command: "bazel test -- //... -//test/community_build/..."
+      bazel_test_command: "bazel test -- //..."
       prerelease: false
       draft: true
       release_files: rules_scala-*.tar.gz

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -307,6 +307,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
 downstream_consumers = use_extension(
     "//test/community_build:downstream_repository.bzl",
     "downstream_consumers",
+    dev_dependency = True,
 )
 downstream_consumers.consumer(
     name = "joern",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -148,7 +148,7 @@
     "//test/community_build:downstream_repository.bzl%downstream_consumers": {
       "general": {
         "bzlTransitiveDigest": "iNbmMqJdb8MiDSGAH41GC2emXRrNu1I+eGxIIxnLxZo=",
-        "usagesDigest": "CwUUnc8bB6arWZ4SSw8Cx/ZV385dh8SV4CyMUYJ42MQ=",
+        "usagesDigest": "/8PBU8M9W7Yv85rmqentU9L/l1HQ0h7cL4nYUJ1NNsU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
- Mark downstream_repository as dev_dependency.
- Skip `test/scalac_exec_group:scalac_action_exec_properties_test` on the release job: it runs a fresh, dedicated nested-bazel output base near the very end of the wildcard test run, when the GitHub-hosted runner's disk is already tight from everything before it -- likely why it failed on both v7.3.0 attempts. Still covered on regular CI, just not on this release job.

(community_build itself is back in the release test command -- #1965 cut `dicer_test` down to 2 executed targets with the rest build-only, which should remove the timing-sensitive surface that was failing it before.)
