### PR TITLE
fix: map source paths explicitly in -paths-for-coverage.txt

### DIFF
--- a/src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java
+++ b/src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java
@@ -16,12 +16,24 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.jacoco.core.instr.Instrumenter;
 import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 
 public final class JacocoInstrumenter implements Worker.Interface {
+
+  /**
+   * Separates the real source path from the class-derived path in a {@code
+   * -paths-for-coverage.txt} entry. Must stay in sync with {@code
+   * JacocoLCOVFormatter.EXEC_PATH_DELIMITER}.
+   */
+  private static final String EXEC_PATH_DELIMITER = "///";
 
   public static void main(String[] args) throws Exception {
     Worker.workerMain(args, new JacocoInstrumenter());
@@ -51,9 +63,13 @@ public final class JacocoInstrumenter implements Worker.Interface {
 
     JarCreator jarCreator = new JarCreator(outPath);
 
+    // Jar-relative paths of every class we instrument, e.g. `/com/example/util/Time$.class`.
+    // Collected during the walk below and used to map sources onto their packages.
+    Set<String> classEntries = new LinkedHashSet<>();
+
     try (FileSystem inFS = FileSystems.newFileSystem(inPath, (ClassLoader) null)) {
       FileVisitor fileVisitor =
-          createInstrumenterVisitor(jacoco, instrumentedClassesDirectory, jarCreator);
+          createInstrumenterVisitor(jacoco, instrumentedClassesDirectory, jarCreator, classEntries);
       inFS.getRootDirectories()
           .forEach(
               root -> {
@@ -77,7 +93,8 @@ public final class JacocoInstrumenter implements Worker.Interface {
       Path pathsForCoverage = instrumentedClassesDirectory.resolve("-paths-for-coverage.txt");
       Files.write(
           pathsForCoverage,
-          String.join("\n", srcs).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+          pathsForCoverageContent(srcs, classEntries)
+              .getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
       jarCreator.addEntry(
           instrumentedClassesDirectory.relativize(pathsForCoverage).toString(), pathsForCoverage);
@@ -93,8 +110,82 @@ public final class JacocoInstrumenter implements Worker.Interface {
     return outputJar.resolveSibling(outputJar + "-coverage-metadata");
   }
 
+  /**
+   * Builds the contents of `-paths-for-coverage.txt`.
+   *
+   * <p>Bazel's {@code JacocoLCOVFormatter} keys coverage data by the class-derived path {@code
+   * <package>/<SourceFileName>} and resolves it against this file with a suffix match, so a source
+   * file only gets attributed coverage when its path on disk happens to end with its package path.
+   * That holds for a Maven-style {@code src/main/scala/com/example/util/Time.scala} layout and
+   * fails for everything else: when {@code util/time/Time.scala} declares {@code package
+   * com.example.util}, nothing matches and the file is left out of the report entirely. See
+   * https://github.com/bazel-contrib/rules_scala/issues/1101.
+   *
+   * <p>The formatter also accepts an explicit mapping, {@code <real path>///<class-derived path>},
+   * which skips the suffix match (added in https://github.com/bazelbuild/bazel/pull/12627). The
+   * {@code package} clause isn't readable from here (sources are passed as paths, not declared as
+   * inputs to this action), but the jar we just walked names every package it contains, so we emit
+   * one mapping per (source, package) pair. A pair that doesn't describe a real class is simply
+   * never looked up. Pairs whose package holds a class named after the source file are emitted
+   * first so that two sources sharing a basename in one jar still resolve correctly.
+   *
+   * <p>The bare source paths are kept at the end, preserving the previous behaviour for layouts
+   * where the suffix match already works.
+   */
+  static String pathsForCoverageContent(String[] srcs, Set<String> classEntries) {
+    Set<String> packageDirs = new LinkedHashSet<>();
+    Set<String> outerClassPaths = new HashSet<>();
+    for (String classEntry : classEntries) {
+      packageDirs.add(packageDirOf(classEntry));
+      outerClassPaths.add(outerClassPathOf(classEntry));
+    }
+
+    List<String> preferred = new ArrayList<>();
+    List<String> rest = new ArrayList<>();
+    for (String packageDir : packageDirs) {
+      for (String src : srcs) {
+        String fileName = src.substring(src.lastIndexOf('/') + 1);
+        String mapping = src + EXEC_PATH_DELIMITER + packageDir + "/" + fileName;
+        if (outerClassPaths.contains(packageDir + "/" + stripExtension(fileName))) {
+          preferred.add(mapping);
+        } else {
+          rest.add(mapping);
+        }
+      }
+    }
+
+    List<String> lines = new ArrayList<>(preferred);
+    lines.addAll(rest);
+    lines.addAll(Arrays.asList(srcs));
+    return String.join("\n", lines);
+  }
+
+  /** `/com/example/util/Time$.class` -> `/com/example/util`; the default package -> `""`. */
+  private static String packageDirOf(String classEntry) {
+    int lastSlash = classEntry.lastIndexOf('/');
+    return lastSlash <= 0 ? "" : classEntry.substring(0, lastSlash);
+  }
+
+  /**
+   * `/com/example/util/Cron$CronExpression.class` -> `/com/example/util/Cron`, i.e. the package
+   * directory plus the outermost class name, which for Scala is usually the source file's basename.
+   */
+  private static String outerClassPathOf(String classEntry) {
+    String withoutExtension = stripExtension(classEntry);
+    int firstDollar = withoutExtension.indexOf('$', withoutExtension.lastIndexOf('/') + 1);
+    return firstDollar < 0 ? withoutExtension : withoutExtension.substring(0, firstDollar);
+  }
+
+  private static String stripExtension(String path) {
+    int lastDot = path.lastIndexOf('.');
+    return lastDot <= path.lastIndexOf('/') ? path : path.substring(0, lastDot);
+  }
+
   private SimpleFileVisitor createInstrumenterVisitor(
-      Instrumenter jacoco, Path instrumentedClassesDirectory, JarCreator jarCreator) {
+      Instrumenter jacoco,
+      Path instrumentedClassesDirectory,
+      JarCreator jarCreator,
+      Set<String> classEntries) {
     return new SimpleFileVisitor<Path>() {
       @Override
       public FileVisitResult visitFile(Path inPath, BasicFileAttributes attrs) {
@@ -133,6 +224,7 @@ public final class JacocoInstrumenter implements Worker.Interface {
                       Files.newOutputStream(tempPath, StandardOpenOption.CREATE_NEW)); ) {
             jacoco.instrument(inStream, outStream, inPath.toString());
           }
+          classEntries.add(inPath.toString());
           jarCreator.addEntry(inPath.toString(), tempPath);
           jarCreator.addEntry(inPath.toString() + ".uninstrumented", inPath);
         } else {

--- a/test/coverage_source_path_mapping/AlsoMapped.scala
+++ b/test/coverage_source_path_mapping/AlsoMapped.scala
@@ -1,0 +1,6 @@
+package com.example.coverage.other
+
+object AlsoMapped {
+  def covered(input: Int): Int =
+    input + 1
+}

--- a/test/coverage_source_path_mapping/BUILD.bazel
+++ b/test/coverage_source_path_mapping/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//scala:scala.bzl", "scala_library", "scala_test")
+
+# Regression test for https://github.com/bazel-contrib/rules_scala/issues/1101. These
+# sources sit directly in `test/coverage_source_path_mapping`, so their paths on disk do
+# not end with their package paths. Coverage can only be attributed to them through an
+# explicit source path mapping in `-paths-for-coverage.txt`, not through the suffix match
+# that `JacocoLCOVFormatter` falls back to.
+
+scala_test(
+    name = "test-source-path-mapping",
+    size = "small",
+    srcs = [
+        "TestSourcePathMapping.scala",
+    ],
+    deps = [
+        ":also_mapped",
+        ":mapped",
+    ],
+)
+
+scala_library(
+    name = "mapped",
+    srcs = [
+        "Mapped.scala",
+    ],
+)
+
+scala_library(
+    name = "also_mapped",
+    srcs = [
+        "AlsoMapped.scala",
+    ],
+)

--- a/test/coverage_source_path_mapping/Mapped.scala
+++ b/test/coverage_source_path_mapping/Mapped.scala
@@ -1,0 +1,9 @@
+package com.example.coverage.mapping
+
+object Mapped {
+  def covered(input: String): String =
+    input.reverse
+
+  def uncovered(input: String): String =
+    input.toUpperCase
+}

--- a/test/coverage_source_path_mapping/TestSourcePathMapping.scala
+++ b/test/coverage_source_path_mapping/TestSourcePathMapping.scala
@@ -1,0 +1,15 @@
+package com.example.coverage.mapping
+
+import com.example.coverage.other.AlsoMapped
+import org.scalatest.flatspec._
+
+class TestSourcePathMapping extends AnyFlatSpec {
+
+  "Mapped.covered" should "work" in {
+    assert(Mapped.covered("ab") == "ba")
+  }
+
+  "AlsoMapped.covered" should "work" in {
+    assert(AlsoMapped.covered(1) == 2)
+  }
+}

--- a/test/coverage_source_path_mapping/expected-coverage.dat
+++ b/test/coverage_source_path_mapping/expected-coverage.dat
@@ -1,0 +1,39 @@
+SF:test/coverage_source_path_mapping/AlsoMapped.scala
+FN:-1,com/example/coverage/other/AlsoMapped$::<clinit> ()V
+FN:3,com/example/coverage/other/AlsoMapped$::<init> ()V
+FN:5,com/example/coverage/other/AlsoMapped$::covered (I)I
+FN:-1,com/example/coverage/other/AlsoMapped::covered (I)I
+FNDA:1,com/example/coverage/other/AlsoMapped$::<clinit> ()V
+FNDA:1,com/example/coverage/other/AlsoMapped$::<init> ()V
+FNDA:1,com/example/coverage/other/AlsoMapped$::covered (I)I
+FNDA:0,com/example/coverage/other/AlsoMapped::covered (I)I
+FNF:4
+FNH:3
+DA:3,1
+DA:5,1
+DA:6,1
+LH:3
+LF:3
+end_of_record
+SF:test/coverage_source_path_mapping/Mapped.scala
+FN:-1,com/example/coverage/mapping/Mapped$::<clinit> ()V
+FN:3,com/example/coverage/mapping/Mapped$::<init> ()V
+FN:5,com/example/coverage/mapping/Mapped$::covered (Ljava/lang/String;)Ljava/lang/String;
+FN:8,com/example/coverage/mapping/Mapped$::uncovered (Ljava/lang/String;)Ljava/lang/String;
+FN:-1,com/example/coverage/mapping/Mapped::covered (Ljava/lang/String;)Ljava/lang/String;
+FN:-1,com/example/coverage/mapping/Mapped::uncovered (Ljava/lang/String;)Ljava/lang/String;
+FNDA:1,com/example/coverage/mapping/Mapped$::<clinit> ()V
+FNDA:1,com/example/coverage/mapping/Mapped$::<init> ()V
+FNDA:1,com/example/coverage/mapping/Mapped$::covered (Ljava/lang/String;)Ljava/lang/String;
+FNDA:0,com/example/coverage/mapping/Mapped$::uncovered (Ljava/lang/String;)Ljava/lang/String;
+FNDA:0,com/example/coverage/mapping/Mapped::covered (Ljava/lang/String;)Ljava/lang/String;
+FNDA:0,com/example/coverage/mapping/Mapped::uncovered (Ljava/lang/String;)Ljava/lang/String;
+FNF:6
+FNH:3
+DA:3,1
+DA:5,1
+DA:8,0
+DA:9,1
+LH:3
+LF:4
+end_of_record

--- a/test/shell/test_coverage_source_path_mapping.sh
+++ b/test/shell/test_coverage_source_path_mapping.sh
@@ -1,0 +1,65 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+# Default to 2.12.21 for `diff` tests because other versions change the output.
+SCALA_VERSION="${SCALA_VERSION:-2.12.21}"
+
+coverage_dat() {
+    echo "$(bazel info bazel-testlogs)/test/coverage_source_path_mapping/test-source-path-mapping/coverage.dat"
+}
+
+run_coverage() {
+    bazel coverage \
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        --instrumentation_filter='^//test/coverage_source_path_mapping[:/]' \
+        //test/coverage_source_path_mapping:test-source-path-mapping
+}
+
+# Prints the LCOV record for a source file, without the surrounding records.
+coverage_record_for() {
+    awk -v src="SF:$1" \
+        '$0 == src {found = 1} found {print} $0 == "end_of_record" {found = 0}' \
+        "$2"
+}
+
+assert_source_has_hit_lines() {
+    local source="test/coverage_source_path_mapping/$1"
+    local dat="$2"
+    local record
+
+    record="$(coverage_record_for "$source" "$dat")"
+
+    if [[ -z "$record" ]]; then
+        fail "no coverage record for ${source} in ${dat}"
+    elif ! grep -qE '^DA:[0-9]+,[1-9]' <<<"$record"; then
+        fail "no covered lines reported for ${source}:" "$record"
+    elif ! grep -qE '^LH:[1-9]' <<<"$record"; then
+        fail "zero hit lines reported for ${source}:" "$record"
+    fi
+}
+
+test_coverage_when_source_path_does_not_end_with_package_path() {
+    run_coverage
+    diff test/coverage_source_path_mapping/expected-coverage.dat "$(coverage_dat)"
+}
+
+# Regression test for https://github.com/bazel-contrib/rules_scala/issues/1101. Without an
+# explicit source path mapping in `-paths-for-coverage.txt`, `JacocoLCOVFormatter` can only
+# match the class-derived path `<package>/<SourceFileName>` against the tail of each source
+# path. That succeeds for a Maven-style layout and fails for these sources, which used to
+# be left out of the report entirely.
+test_coverage_reports_hit_lines_for_every_instrumented_source() {
+    local dat
+
+    run_coverage
+    dat="$(coverage_dat)"
+
+    assert_source_has_hit_lines AlsoMapped.scala "$dat" &&
+        assert_source_has_hit_lines Mapped.scala "$dat"
+}
+
+$runner test_coverage_when_source_path_does_not_end_with_package_path
+$runner test_coverage_reports_hit_lines_for_every_instrumented_source

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -13,3 +13,4 @@ test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 . "${test_dir}"/test_coverage_scalatest.sh
 . "${test_dir}"/test_coverage_equals_in_target.sh
 . "${test_dir}"/test_coverage_scalatest_resources.sh
+. "${test_dir}"/test_coverage_source_path_mapping.sh


### PR DESCRIPTION
### Description

Emit explicit `<real source path>///<class-derived path>` mappings in `-paths-for-coverage.txt` so coverage is attributed to sources whose path on disk does not end with their package path.

`JacocoInstrumenter` writes `-paths-for-coverage.txt` as a bare newline-joined list of source paths. Bazel's `JacocoLCOVFormatter` keys coverage data by the path it derives from the *class* — `<package>/<SourceFileName>` — and resolves it against that list with a **suffix match**. A source file therefore only gets coverage when its path happens to end with its package path: `src/main/scala/com/example/util/Time.scala` works, while `util/time/Time.scala` declaring `package com.example.util` is silently left out of the report.

[bazelbuild/bazel#12627](https://github.com/bazelbuild/bazel/pull/12627) added an explicit mapping form to that file — `<real source path>///<class-derived path>` — which bypasses the suffix match entirely (`parts[1].equals("/" + sourceFile)`). This PR adopts it.

The `package` clause isn't readable from the instrumenter (sources are passed as paths, not declared as inputs to the action), but the jar being walked names every package directory it contains, so the instrumenter emits one mapping per (source, package directory) pair. Pairs that don't describe a real class are simply never looked up; pairs whose package holds a class named after the source file are emitted first so two sources sharing a basename in one jar still resolve. The bare source paths are kept at the end, so layouts where the suffix match already works behave exactly as before.

Fixes #1101

### Motivation

`bazel coverage` currently produces no data at all for any repository that does not mirror its package hierarchy in its directory layout — the case in #1101, open since 2020. Nothing fails and nothing warns; the affected records are just absent from `coverage.dat`, which makes the whole feature quietly useless outside a Maven-style tree. This is exactly what the mapping format in bazelbuild/bazel#12627 was added for, and rules_scala had never adopted it.

### Testing

- New `test/coverage_source_path_mapping`, wired into `./test_coverage.sh` alongside the existing coverage fixtures. Its sources sit directly in the package directory and declare deep packages (`com.example.coverage.mapping`, `com.example.coverage.other`), so their paths do not end with their package paths — the #1101 case, which no existing fixture covers. Two assertions: a golden `expected-coverage.dat` diff, and an explicit check that each instrumented source has `DA:` lines with non-zero hit counts and a non-zero `LH:`.
- **Both new assertions fail without the `JacocoInstrumenter.java` change.** Verified by reverting just that file: the produced `coverage.dat` is *empty* — the two sources are dropped from the report entirely — so the golden diff fails and the hit-line check reports `no coverage record for test/coverage_source_path_mapping/AlsoMapped.scala`.
- `./test_coverage.sh` passes in full (9 test cases). The four pre-existing goldens — `coverage_scalatest`, `coverage_specs2_with_junit`, `coverage_filename_encoding`, `coverage_scalatest_resources` — are byte-identical with the change applied; I also re-ran `//test/coverage_scalatest:test-scalatest` with `--nocache_test_results` and diffed it against the checked-in golden to confirm.
- `bazel build //...` and `bazel run //tools:lint_check` are clean.

Tested on macOS (arm64, Bazel 8) only; I have not run the suite on Linux.
