### PR TITLE
ci: Tag the remaining disk-heavy nested-bazel tests no-release

### DIFF
--- a/test/argument_file_in_runner/BUILD
+++ b/test/argument_file_in_runner/BUILD
@@ -19,6 +19,7 @@ sh_test(
         # after that toolchain changes.
         "external",
         "local",
+        "no-release",
         "requires-network",
     ],
     # rules_scala doesn't support argfiles on Windows yet.

--- a/test/build_event_protocol/BUILD
+++ b/test/build_event_protocol/BUILD
@@ -20,6 +20,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
         tags = [
             "exclusive",
             "local",
+            "no-release",
             "requires-network",
         ],
     )

--- a/test/bzlmod_macros/bzlmod_macros.bzl
+++ b/test/bzlmod_macros/bzlmod_macros.bzl
@@ -45,6 +45,7 @@ _NESTED_BAZEL_DATA = [
 _NESTED_BAZEL_TAGS = [
     "exclusive",
     "local",
+    "no-release",
     "requires-network",
 ]
 

--- a/test/compiler_sources_integrity_test/BUILD
+++ b/test/compiler_sources_integrity_test/BUILD
@@ -32,6 +32,7 @@ _NESTED_BAZEL_DATA = [
 
 _NESTED_BAZEL_TAGS = [
     "local",
+    "no-release",
     "requires-network",
     "exclusive",
 ]

--- a/test/custom_reporter/BUILD
+++ b/test/custom_reporter/BUILD
@@ -23,6 +23,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/diagnostics_reporter/BUILD
+++ b/test/diagnostics_reporter/BUILD
@@ -135,6 +135,7 @@ _FIXTURES = [
         tags = [
             "exclusive",
             "local",
+            "no-release",
             "requires-network",
         ],
     )

--- a/test/disappearing_class/BUILD
+++ b/test/disappearing_class/BUILD
@@ -30,6 +30,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/env_attribute_expansion/BUILD
+++ b/test/env_attribute_expansion/BUILD
@@ -23,6 +23,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/fetch_sources/BUILD
+++ b/test/fetch_sources/BUILD
@@ -23,6 +23,7 @@ sh_test(
     tags = [
         "exclusive",
         "local",
+        "no-release",
         "requires-network",
     ],
 )
@@ -42,6 +43,7 @@ sh_test(
     tags = [
         "exclusive",
         "local",
+        "no-release",
         "requires-network",
     ],
 )
@@ -61,6 +63,7 @@ sh_test(
     tags = [
         "exclusive",
         "local",
+        "no-release",
         "requires-network",
     ],
 )
@@ -80,6 +83,7 @@ sh_test(
     tags = [
         "exclusive",
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/macros/BUILD
+++ b/test/macros/BUILD
@@ -113,6 +113,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/scala_config/BUILD
+++ b/test/scala_config/BUILD
@@ -22,6 +22,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
         tags = [
             "exclusive",
             "local",
+            "no-release",
             "requires-network",
         ],
     )
@@ -47,6 +48,7 @@ sh_test(
     tags = [
         "exclusive",
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/scala_junit_test/BUILD
+++ b/test/scala_junit_test/BUILD
@@ -237,6 +237,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )
@@ -255,6 +256,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )
@@ -371,6 +373,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/scala_proto_library_action_label/BUILD
+++ b/test/scala_proto_library_action_label/BUILD
@@ -17,6 +17,7 @@ sh_test(
     tags = [
         "external",
         "local",
+        "no-release",
         "requires-network",
     ],
 )

--- a/test/scaladoc/BUILD
+++ b/test/scaladoc/BUILD
@@ -77,7 +77,7 @@ sh_test(
          "//:MODULE.bazel",
          "//test/expect_build_failure:nested_bazel.sh"
     ],
-    tags = ["local", "requires-network"],
+    tags = ["local", "no-release", "requires-network"],
 )
 
 # Test that scaladoc for intransitive deps generates docs only for B (not A).
@@ -94,7 +94,7 @@ sh_test(
          "//:MODULE.bazel",
          "//test/expect_build_failure:nested_bazel.sh"
     ],
-    tags = ["local", "requires-network"],
+    tags = ["local", "no-release", "requires-network"],
 )
 
 # Test that scaladoc for transitive external deps works (just build succeeds).

--- a/test/semanticdb/BUILD
+++ b/test/semanticdb/BUILD
@@ -152,6 +152,7 @@ sh_test(
     data = _SEMANTICDB_FIXTURE_DATA + [":all_lib_fixture_actions"],
     tags = [
         "exclusive",
+        "no-release",
         "no-remote-exec",
         "no-sandbox",
         "requires-network",
@@ -165,6 +166,7 @@ sh_test(
     data = _SEMANTICDB_FIXTURE_DATA + [":lib_with_tempsrc_fixture_actions"],
     tags = [
         "exclusive",
+        "no-release",
         "no-remote-exec",
         "no-sandbox",
         "requires-network",
@@ -189,6 +191,7 @@ sh_test(
         ),
         tags = [
             "exclusive",
+            "no-release",
             "no-remote-exec",
             "no-sandbox",
             "requires-network",

--- a/test/toolchain_macros_repo_mapping/BUILD
+++ b/test/toolchain_macros_repo_mapping/BUILD
@@ -16,6 +16,7 @@ sh_test(
     ],
     tags = [
         "local",
+        "no-release",
         "requires-network",
     ],
 )


### PR DESCRIPTION
### Description

Extends the `no-release` tag (introduced for `scalac_action_exec_properties_test` and `community_build`) to the rest of the nested-bazel test family: every `sh_test` whose script sets up its own dedicated nested Bazel output base (~1GB each, extracted fresh into `/tmp`). 68 targets across 16 BUILD files.

Left out: `expect_build_failure`/`expect_analysis_failure` fixtures (already share 3 lanes, not disk-heavy individually) and `no_recompilation_test` (already `exclusive`, separate concern).

### Motivation

The last two release runs both hit "No space left on device" on GitHub's 14GB-disk runner. Excluding one target at a time just moved the failure to whichever test happened to run last. These are already covered by the regular BuildKite CI (much bigger machines) on every PR and on master before a release is cut, so the release job doesn't need to re-run them.