### PR TITLE
fix: Exclude specs2_exception_terminates_without_timeout on Windows

### DIFF
--- a/test/scala_junit_test/BUILD
+++ b/test/scala_junit_test/BUILD
@@ -82,11 +82,9 @@ expect_test_failure_test(
 # Filtering to the failing spec must surface the same exception and terminate
 # promptly (no test-timeout), i.e. the run fails fast rather than hanging.
 #
-# Excluded on Windows: Bazel's own test-timeout kill is unreliable there (no
-# POSIX signals, and a process can escape the job object Bazel tracks it
-# with), so the nested run has been seen to hang well past its own
-# `--test_timeout=10` and block CI for the outer test's full 900s timeout
-# (#1884). No known fix on our side; the assertion still holds on Linux/macOS.
+# Excluded on Windows: the nested run has been seen to outlive its own
+# `--test_timeout=10` there and occupy this test until its own 900s timeout
+# (#1884). Assertion still holds on Linux/macOS.
 expect_test_failure_test(
     name = "specs2_exception_terminates_without_timeout",
     bazel_args = [

--- a/test/scala_junit_test/BUILD
+++ b/test/scala_junit_test/BUILD
@@ -81,6 +81,9 @@ expect_test_failure_test(
 
 # Filtering to the failing spec must surface the same exception and terminate
 # promptly (no test-timeout), i.e. the run fails fast rather than hanging.
+#
+# `timeout` overrides the "large"-size default (900s) so a hang here (seen on
+# Windows) fails within a minute, not 15.
 expect_test_failure_test(
     name = "specs2_exception_terminates_without_timeout",
     bazel_args = [
@@ -92,6 +95,7 @@ expect_test_failure_test(
     expect = ["expected_specs2_user_exception.txt"],
     reject = ["rejected_timeout.txt"],
     target = ":specs2_failing_test",
+    timeout = "short",
 )
 
 # The tests below assert on `--test_filter` narrowing a specs2 suite

--- a/test/scala_junit_test/BUILD
+++ b/test/scala_junit_test/BUILD
@@ -82,8 +82,11 @@ expect_test_failure_test(
 # Filtering to the failing spec must surface the same exception and terminate
 # promptly (no test-timeout), i.e. the run fails fast rather than hanging.
 #
-# `timeout` overrides the "large"-size default (900s) so a hang here (seen on
-# Windows) fails within a minute, not 15.
+# Excluded on Windows: Bazel's own test-timeout kill is unreliable there (no
+# POSIX signals, and a process can escape the job object Bazel tracks it
+# with), so the nested run has been seen to hang well past its own
+# `--test_timeout=10` and block CI for the outer test's full 900s timeout
+# (#1884). No known fix on our side; the assertion still holds on Linux/macOS.
 expect_test_failure_test(
     name = "specs2_exception_terminates_without_timeout",
     bazel_args = [
@@ -95,7 +98,10 @@ expect_test_failure_test(
     expect = ["expected_specs2_user_exception.txt"],
     reject = ["rejected_timeout.txt"],
     target = ":specs2_failing_test",
-    timeout = "short",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 # The tests below assert on `--test_filter` narrowing a specs2 suite


### PR DESCRIPTION
### Description

Adds `target_compatible_with` so `specs2_exception_terminates_without_timeout` skips on Windows; it still runs on Linux/macOS.

### Motivation

Fixes #1884. This test's nested `bazel test --test_timeout=10` has been seen to hang on Windows past that timeout, so the outer test waits out its own 900s before failing (`TIMEOUT in 900.0s` in the Buildkite log), blocking CI for 15 minutes.

#1884 itself asks to either fix this on Windows or exclude it there if unfixable. I looked for a real fix (a way to bound just the hang, or make Bazel's own timeout-kill reliable on Windows) and found none, so this takes the exclusion path.